### PR TITLE
Allow client to connect to deployed server

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,8 @@
     "typescript": "3.5.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "REACT_APP_ENVIRONMENT=development react-scripts start",
+    "start:mock": "REACT_APP_ENVIRONMENT=mock react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/client/src/api/getCourseInfo.ts
+++ b/client/src/api/getCourseInfo.ts
@@ -1,7 +1,7 @@
 import { DbCourse, dbCourseToCourseData } from '../interfaces/DbCourse'
 import { CourseData } from '../interfaces/CourseData'
 
-const API_URL = 'http://localhost:3001/api'
+const API_URL = process.env.REACT_APP_ENVIRONMENT === 'development' ? 'http://localhost:3001/api' : 'https://notangles-server.csesoc.unsw.edu.au/api'
 
 /**
  * Fetches the information of a specified course

--- a/client/src/api/getCoursesList.ts
+++ b/client/src/api/getCoursesList.ts
@@ -1,6 +1,6 @@
 import { CoursesList } from '../interfaces/CourseOverview'
 
-const API_URL = 'http://localhost:3001/api'
+const API_URL = process.env.REACT_APP_ENVIRONMENT === 'development' ? 'http://localhost:3001/api' : 'https://notangles-server.csesoc.unsw.edu.au/api'
 
 /**
  * Fetches a list of course objects, where each course object contains 


### PR DESCRIPTION
Run the client with `npm run start:mock` to make it connect to the deployed server instead of the local server. 