### PR TITLE
Feature/51 material timetable

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -966,17 +966,17 @@
       "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA=="
     },
     "@emotion/is-prop-valid": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.3.tgz",
-      "integrity": "sha512-We7VBiltAJ70KQA0dWkdPMXnYoizlxOXpvtjmu5/MBnExd+u0PGgV27WCYanmLAbCwAU30Le/xA0CQs/F/Otig==",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "requires": {
-        "@emotion/memoize": "0.7.3"
+        "@emotion/memoize": "0.7.4"
       },
       "dependencies": {
         "@emotion/memoize": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.3.tgz",
-          "integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow=="
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
         }
       }
     },
@@ -1774,12 +1774,11 @@
       }
     },
     "@types/react-native": {
-      "version": "0.60.16",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.60.16.tgz",
-      "integrity": "sha512-IH9QvrvlZRrtfVi5XiMuh+hT5SvgcGzx4szEi+Vge3qmvU3jlboEsXg4iWRPtgFx3eMIZoAksR3kbgVrB8ctLA==",
+      "version": "0.62.5",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.62.5.tgz",
+      "integrity": "sha512-x6ZBbo752yAw5XUarOyh53oNgMuafL4EhWEbd4ARSMK6Y7nTRm2a1tBHy8Fp7h7ji0XXJrxNRTXGJRRP3+MWzg==",
       "dev": true,
       "requires": {
-        "@types/prop-types": "*",
         "@types/react": "*"
       }
     },
@@ -1812,11 +1811,12 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
     },
     "@types/styled-components": {
-      "version": "4.1.19",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-4.1.19.tgz",
-      "integrity": "sha512-nDkoTQ8ItcJiyEvTa24TwsIpIfNKCG+Lq0LvAwApOcjQ8OaeOOCg66YSPHBePHUh6RPt1LA8aEzRlgWhQPFqPg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.0.tgz",
+      "integrity": "sha512-ZFlLCuwF5r+4Vb7JUmd+Yr2S0UBdBGmI7ctFTgJMypIp3xOHI4LCFVn2dKMvpk6xDB2hLRykrEWMBwJEpUAUIQ==",
       "dev": true,
       "requires": {
+        "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
         "@types/react-native": "*",
         "csstype": "^2.2.0"
@@ -2553,9 +2553,9 @@
       "integrity": "sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ=="
     },
     "babel-plugin-styled-components": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz",
-      "integrity": "sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz",
+      "integrity": "sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -4282,13 +4282,20 @@
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
     "css-to-react-native": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
-      "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^3.3.0"
+        "postcss-value-parser": "^4.0.2"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+          "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
+        }
       }
     },
     "css-tree": {
@@ -6924,11 +6931,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "is-what": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.3.1.tgz",
-      "integrity": "sha512-seFn10yAXy+yJlTRO+8VfiafC+0QJanGLMPTBWLrJm/QPauuchy0UXh8B6H5o9VA8BAzk0iYievt6mNp6gfaqA=="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -8627,14 +8629,6 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      }
-    },
-    "merge-anything": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.1.tgz",
-      "integrity": "sha512-dYOIAl9GFCJNctSIHWOj9OJtarCjsD16P8ObCl6oxrujAG+kOvlwJuOD9/O9iYZ9aTi1RGpGTG9q9etIvuUikQ==",
-      "requires": {
-        "is-what": "^3.3.1"
       }
     },
     "merge-deep": {
@@ -12230,23 +12224,32 @@
       }
     },
     "styled-components": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.0.tgz",
-      "integrity": "sha512-xQ6vTI/0zNjZ1BBDRxyjvBddrxhQ3DxjeCdaLM1lSn5FDnkTOQgRkmWvcUiTajqc5nJqKVl+7sUioMqktD0+Zw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.1.0.tgz",
+      "integrity": "sha512-0Qs2wEkFBXHFlysz6CV831VG6HedcrFUwChjnWylNivsx14MtmqQsohi21rMHZxzuTba063dEyoe/SR6VGJI7Q==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@emotion/is-prop-valid": "^0.8.1",
-        "@emotion/unitless": "^0.7.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
         "babel-plugin-styled-components": ">= 1",
-        "css-to-react-native": "^2.2.2",
-        "memoize-one": "^5.0.0",
-        "merge-anything": "^2.2.4",
-        "prop-types": "^15.5.4",
-        "react-is": "^16.6.0",
-        "stylis": "^3.5.0",
-        "stylis-rule-sheet": "^0.0.10",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "@emotion/stylis": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+          "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+        },
+        "@emotion/unitless": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+          "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+        }
       }
     },
     "stylehacks": {
@@ -12270,16 +12273,6 @@
           }
         }
       }
-    },
-    "stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
-    },
-    "stylis-rule-sheet": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
     "react-select": "^3.0.4",
-    "styled-components": "^4.4.0",
+    "styled-components": "^5.1.0",
     "typescript": "3.5.1"
   },
   "scripts": {
@@ -45,6 +45,6 @@
     ]
   },
   "devDependencies": {
-    "@types/styled-components": "^4.1.19"
+    "@types/styled-components": "^5.1.0"
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,7 +23,8 @@ export interface CourseOption {
 
 const ContentWrapper = styled.div`
   text-align: center;
-  padding-top: calc(64px + 30px);
+  margin-top: 64px;
+  padding-top: 30px;
   padding-left: 30px;
   padding-right: 30px;
   height: 100vh;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,7 +23,7 @@ export interface CourseOption {
 
 const StyledApp = styled.div`
   height: 85vh;
-  padding: 10px 20%;
+  padding: 10px 15%;
 
   display: grid;
   grid-template-rows: 1fr 1fr 90%
@@ -48,7 +48,7 @@ const App: FunctionComponent = () => {
   const assignedColors = useColorMapper(
     selectedCourses.map(course => course.courseCode)
   )
-  
+
   useEffect(() => {
     storage.set('is12HourMode', is12HourMode)
   }, [is12HourMode])

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,12 +21,25 @@ export interface CourseOption {
   label: string
 }
 
-const StyledApp = styled.div`
-  height: 85vh;
-  padding: 10px 15%;
+const ContentWrapper = styled.div`
+  text-align: center;
+  padding-top: calc(64px + 30px);
+  padding-bottom: 30px;
+  padding-left: 30px;
+  padding-right: 30px;
+  height: 100vh;
+  box-sizing: border-box;
+`
+
+const Content = styled.div`
+  width: 1200px;
+  min-width: 600px;
+  max-width: 100%;
+  height: 100%;
+  margin: auto;
 
   display: grid;
-  grid-template-rows: 1fr 1fr 90%
+  grid-template-rows: min-content min-content auto;
   grid-template-columns: auto;
 
   text-align: center;
@@ -91,30 +104,32 @@ const App: FunctionComponent = () => {
   return (
     <div className="App">
       <Navbar />
-      <StyledApp>
-        <SelectWrapper>
-          <CourseSelect
-            onChange={handleSelectCourse}
-          />
-        </SelectWrapper>
-        <DndProvider backend={HTML5Backend}>
-          <Inventory
-            selectedCourses={selectedCourses}
-            selectedClassIds={selectedClassIds}
-            assignedColors={assignedColors}
-            removeCourse={handleRemoveCourse}
-            removeClass={handleRemoveClass}
-          />
-          <Timetable
-            selectedCourses={selectedCourses}
-            selectedClassIds={selectedClassIds}
-            assignedColors={assignedColors}
-            is12HourMode={is12HourMode}
-            setIs12HourMode={setIs12HourMode}
-            onSelectClass={handleSelectClass}
-          />
-        </DndProvider>
-      </StyledApp>
+      <ContentWrapper>
+        <Content>
+          <SelectWrapper>
+            <CourseSelect
+              onChange={handleSelectCourse}
+            />
+          </SelectWrapper>
+          <DndProvider backend={HTML5Backend}>
+            <Inventory
+              selectedCourses={selectedCourses}
+              selectedClassIds={selectedClassIds}
+              assignedColors={assignedColors}
+              removeCourse={handleRemoveCourse}
+              removeClass={handleRemoveClass}
+            />
+            <Timetable
+              selectedCourses={selectedCourses}
+              selectedClassIds={selectedClassIds}
+              assignedColors={assignedColors}
+              is12HourMode={is12HourMode}
+              setIs12HourMode={setIs12HourMode}
+              onSelectClass={handleSelectClass}
+            />
+          </DndProvider>
+        </Content>
+      </ContentWrapper>
     </div>
   )
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,7 +24,6 @@ export interface CourseOption {
 const ContentWrapper = styled.div`
   text-align: center;
   padding-top: calc(64px + 30px);
-  padding-bottom: 30px;
   padding-left: 30px;
   padding-right: 30px;
   height: 100vh;

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -24,8 +24,7 @@ const NavbarBox = styled.div`
 `
 const StyledNavBar = styled(AppBar)`
   background: rgb(54,119,245);
-  margin-bottom:30px;
-  position: static;
+  position: fixed;
 `
 const NavbarTitle = styled(Typography)`
   flex-grow: 1;

--- a/client/src/components/inventory/InventoryCourseClass.tsx
+++ b/client/src/components/inventory/InventoryCourseClass.tsx
@@ -4,7 +4,6 @@ import { useDrag } from 'react-dnd'
 
 interface StyledInventoryCourseClassProps {
   isDragging: boolean
-  color: string
   backgroundColor: string
 }
 
@@ -14,14 +13,14 @@ const StyledInventoryCourseClass = styled.div<StyledInventoryCourseClassProps>`
 
   float: left;
   margin: 10px;
-  
+
   display: inline-flex;
   align-items: center;
   justify-content: center;
 
   font-size: 0.7rem;
-  
-  color: ${props => props.color};
+
+  color: white;
   background-color: ${props => props.backgroundColor};
   opacity: ${({ isDragging }) => (isDragging ? 0.5 : 1)};
   cursor: move;
@@ -30,24 +29,14 @@ const StyledInventoryCourseClass = styled.div<StyledInventoryCourseClassProps>`
 export interface InventoryCourseClassProps {
   courseCode: string
   activity: string
-  colour: string
+  color: string
 }
 
 const InventoryCourseClass: React.FC<InventoryCourseClassProps> = ({
   courseCode,
   activity,
-  colour,
+  color,
 }) => {
-  const bgAndTextColorPairs: Record<string, string> = {
-    violet: 'white',
-    indigo: 'white',
-    green: 'white',
-    blue: 'white',
-    yellow: 'black',
-    orange: 'black',
-    red: 'black',
-  }
-
   const [{ isDragging }, drag] = useDrag({
     item: { type: `${courseCode}-${activity}` },
     collect: monitor => ({
@@ -59,8 +48,7 @@ const InventoryCourseClass: React.FC<InventoryCourseClassProps> = ({
     <StyledInventoryCourseClass
       ref={drag}
       isDragging={isDragging}
-      backgroundColor={colour}
-      color={bgAndTextColorPairs[colour]}
+      backgroundColor={color}
     >
       {`${courseCode}`}
         <br/>

--- a/client/src/components/inventory/InventoryCourseClass.tsx
+++ b/client/src/components/inventory/InventoryCourseClass.tsx
@@ -24,6 +24,7 @@ const StyledInventoryCourseClass = styled.div<StyledInventoryCourseClassProps>`
   background-color: ${props => props.backgroundColor};
   opacity: ${({ isDragging }) => (isDragging ? 0.5 : 1)};
   cursor: move;
+  border-radius: 6px;
 `
 
 export interface InventoryCourseClassProps {

--- a/client/src/components/inventory/InventoryRow.tsx
+++ b/client/src/components/inventory/InventoryRow.tsx
@@ -54,7 +54,7 @@ const InventoryRow: React.FC<InventoryRowProps> = ({
           key={`${course.courseCode}-${activity}`}
           courseCode={course.courseCode}
           activity={activity}
-          colour={color}
+          color={color}
         />
       ))
 

--- a/client/src/components/timetable/DroppedClasses.tsx
+++ b/client/src/components/timetable/DroppedClasses.tsx
@@ -17,7 +17,7 @@ const StyledCourseClass = styled(Card)<{
   opacity: ${props => (props.isDragging ? 0.5 : 1)};
   color: white;
   cursor: move;
-  font-size: 0.7rem;
+  font-size: 0.9rem;
   border-radius: 6px;
   padding: 6px;
   margin: 3px;
@@ -53,9 +53,7 @@ const DroppedClass: FunctionComponent<DroppedClassProps> = ({
       classTime={classTime}
     >
       <p style={{ textAlign: 'center', marginBottom: 0 }}>
-      {`${courseCode}`}
-        <br/>
-      {`${activity}`}
+      <b>{courseCode} {activity}</b>
       </p>
       <p style={{ textAlign: 'center', marginTop: 0 }}>{`${classTime.location}`}</p>
     </StyledCourseClass>

--- a/client/src/components/timetable/DroppedClasses.tsx
+++ b/client/src/components/timetable/DroppedClasses.tsx
@@ -5,24 +5,37 @@ import Card from '@material-ui/core/Card'
 import { CourseData, Period, ClassData, ClassTime } from '../../interfaces/CourseData'
 import { weekdayToXCoordinate, timeToIndex } from './Dropzone'
 
-const StyledCourseClass = styled(Card)<{
+const StyledCourseClass = styled(Card).withConfig({
+  shouldForwardProp: prop => ["children"].includes(prop)
+})<{
   isDragging: boolean
   classTime: Period
   backgroundColor: string
 }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
   grid-column: ${props => weekdayToXCoordinate(props.classTime.time.day) + 1};
   grid-row: ${props => timeToIndex(props.classTime.time.start)} /
-    ${props => timeToIndex(props.classTime.time.end)};
+            ${props => timeToIndex(props.classTime.time.end)};
+
   background-color: ${props => props.backgroundColor};
   opacity: ${props => (props.isDragging ? 0.5 : 1)};
   color: white;
   cursor: move;
   font-size: 0.9rem;
   border-radius: 6px;
+
   padding: 6px;
-  margin: 3px;
+  margin: 2px;
   position: relative;
-  bottom: 1px;
+  bottom: 0.5px;
+
+  p {
+    margin: 2px 0;
+  }
 `
 
 interface DroppedClassProps {
@@ -52,10 +65,8 @@ const DroppedClass: FunctionComponent<DroppedClassProps> = ({
       backgroundColor={color}
       classTime={classTime}
     >
-      <p style={{ textAlign: 'center', marginBottom: 0 }}>
-      <b>{courseCode} {activity}</b>
-      </p>
-      <p style={{ textAlign: 'center', marginTop: 0 }}>{`${classTime.location}`}</p>
+      <p><b>{courseCode} {activity}</b></p>
+      <p>{`${classTime.locationShort}`}</p>
     </StyledCourseClass>
   )
 }
@@ -78,7 +89,7 @@ const buildDroppedClass = ({
   assignedColors: Record<string, string>
 }): JSX.Element => (
     <DroppedClass
-      key={`${classData.classId}-${JSON.stringify(classTime)}`}
+      key={`${classData.classId}-${JSON.stringify(classTime)}-${Math.random()}`} // Math.random() is a temporary patch
       activity={classData.activity}
       courseCode={course.courseCode}
       color={assignedColors[course.courseCode]}

--- a/client/src/components/timetable/DroppedClasses.tsx
+++ b/client/src/components/timetable/DroppedClasses.tsx
@@ -93,7 +93,7 @@ const buildDroppedClass = ({
   assignedColors: Record<string, string>
 }): JSX.Element => (
     <DroppedClass
-      key={`${classData.classId}-${JSON.stringify(classTime)}-${Math.random()}`} // Math.random() is a temporary patch
+      key={`${classData.classId}-${JSON.stringify(classTime)}`}
       activity={classData.activity}
       courseCode={course.courseCode}
       color={assignedColors[course.courseCode]}

--- a/client/src/components/timetable/DroppedClasses.tsx
+++ b/client/src/components/timetable/DroppedClasses.tsx
@@ -1,23 +1,28 @@
 import React, { FunctionComponent } from 'react'
 import { useDrag } from 'react-dnd'
 import styled from 'styled-components'
+import Card from '@material-ui/core/Card'
 import { CourseData, Period, ClassData, ClassTime } from '../../interfaces/CourseData'
 import { weekdayToXCoordinate, timeToIndex } from './Dropzone'
 
-const StyledCourseClass = styled.div<{
+const StyledCourseClass = styled(Card)<{
   isDragging: boolean
   classTime: Period
   backgroundColor: string
-  color: string
 }>`
   grid-column: ${props => weekdayToXCoordinate(props.classTime.time.day) + 1};
   grid-row: ${props => timeToIndex(props.classTime.time.start)} /
     ${props => timeToIndex(props.classTime.time.end)};
-  color: ${props => props.color};
   background-color: ${props => props.backgroundColor};
   opacity: ${props => (props.isDragging ? 0.5 : 1)};
+  color: white;
   cursor: move;
   font-size: 0.7rem;
+  border-radius: 6px;
+  padding: 6px;
+  margin: 3px;
+  position: relative;
+  bottom: 1px;
 `
 
 interface DroppedClassProps {
@@ -25,16 +30,6 @@ interface DroppedClassProps {
   courseCode: string
   color: string
   classTime: Period
-}
-
-const bgAndTextColorPairs: Record<string, string> = {
-  violet: 'white',
-  indigo: 'white',
-  green: 'white',
-  blue: 'white',
-  yellow: 'black',
-  orange: 'black',
-  red: 'black',
 }
 
 const DroppedClass: FunctionComponent<DroppedClassProps> = ({
@@ -55,7 +50,6 @@ const DroppedClass: FunctionComponent<DroppedClassProps> = ({
       ref={drag}
       isDragging={isDragging}
       backgroundColor={color}
-      color={bgAndTextColorPairs[color]}
       classTime={classTime}
     >
       <p style={{ textAlign: 'center', marginBottom: 0 }}>

--- a/client/src/components/timetable/DroppedClasses.tsx
+++ b/client/src/components/timetable/DroppedClasses.tsx
@@ -28,13 +28,17 @@ const StyledCourseClass = styled(Card).withConfig({
   font-size: 0.9rem;
   border-radius: 6px;
 
-  padding: 6px;
+  padding: 10px;
   margin: 2px;
   position: relative;
   bottom: 0.5px;
 
   p {
-    margin: 2px 0;
+    margin: 0 0;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 `
 

--- a/client/src/components/timetable/Dropzone.tsx
+++ b/client/src/components/timetable/Dropzone.tsx
@@ -19,7 +19,7 @@ export const timeToIndex = (time: string) => {
   return Number(time.split(':')[0]) - 7
 }
 
-const StyledCell = styled(Card)<{
+const StyledCell = styled.div<{
   classTime: Period
   canDrop: boolean
   color: string
@@ -32,16 +32,9 @@ const StyledCell = styled(Card)<{
   grid-row: ${props => timeToIndex(props.classTime.time.start)} /
     ${props => timeToIndex(props.classTime.time.end)};
   background-color: ${props => props.color};
-  opacity: 0.3;
 
-  font-size: 0.7rem;
-  border-radius: 6px;
-  padding: 6px;
-  margin: 3px;
-  position: relative;
-  bottom: 1px;
-
-  ${props => !props.canDrop && 'display: none'};
+  transition: opacity 200ms;
+  opacity: ${props => props.canDrop ? 0.3 : 0};
 `
 
 interface CellProps {

--- a/client/src/components/timetable/Dropzone.tsx
+++ b/client/src/components/timetable/Dropzone.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import styled from 'styled-components'
+import Card from '@material-ui/core/Card'
 import { useDrop } from 'react-dnd'
 import { Period } from '../../interfaces/CourseData'
+import CardContent from '@material-ui/core/CardContent'
 
 export const weekdayToXCoordinate = (weekDay: string) => {
   const conversionTable: Record<string, number> = {
@@ -18,14 +20,11 @@ export const timeToIndex = (time: string) => {
   return Number(time.split(':')[0]) - 7
 }
 
-const StyledCell = styled.div<{
+const StyledCell = styled(Card)<{
   classTime: Period
   canDrop: boolean
   color: string
 }>`
-  border: 0.2px solid;
-  border-color: rgba(0, 0, 0, 0.2);
-
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -33,11 +32,16 @@ const StyledCell = styled.div<{
   grid-column: ${props => weekdayToXCoordinate(props.classTime.time.day) + 1};
   grid-row: ${props => timeToIndex(props.classTime.time.start)} /
     ${props => timeToIndex(props.classTime.time.end)};
-  border: 3px solid ${props => props.color};
-  background-color: white;
-  
+  background-color: ${props => props.color};
+  opacity: 0.5;
+
   font-size: 0.7rem;
-  
+  border-radius: 6px;
+  padding: 6px;
+  margin: 3px;
+  position: relative;
+  bottom: 1px;
+
   ${props => !props.canDrop && 'display: none'};
 `
 
@@ -71,9 +75,7 @@ const Dropzone: React.FC<CellProps> = ({
       classTime={classTime}
       canDrop={canDrop}
       color={color}
-    >
-      {`${courseCode} ${activity}`}
-    </StyledCell>
+    />
   )
 }
 

--- a/client/src/components/timetable/Dropzone.tsx
+++ b/client/src/components/timetable/Dropzone.tsx
@@ -33,7 +33,7 @@ const StyledCell = styled(Card)<{
   grid-row: ${props => timeToIndex(props.classTime.time.start)} /
     ${props => timeToIndex(props.classTime.time.end)};
   background-color: ${props => props.color};
-  opacity: 0.5;
+  opacity: 0.3;
 
   font-size: 0.7rem;
   border-radius: 6px;

--- a/client/src/components/timetable/Dropzone.tsx
+++ b/client/src/components/timetable/Dropzone.tsx
@@ -35,6 +35,7 @@ const StyledCell = styled.div<{
 
   transition: opacity 200ms;
   opacity: ${props => props.canDrop ? 0.3 : 0};
+  pointer-events: ${props => props.canDrop ? "auto" : "none"};
 `
 
 interface CellProps {

--- a/client/src/components/timetable/Dropzone.tsx
+++ b/client/src/components/timetable/Dropzone.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import Card from '@material-ui/core/Card'
 import { useDrop } from 'react-dnd'
 import { Period } from '../../interfaces/CourseData'
-import CardContent from '@material-ui/core/CardContent'
 
 export const weekdayToXCoordinate = (weekDay: string) => {
   const conversionTable: Record<string, number> = {

--- a/client/src/components/timetable/Timetable.tsx
+++ b/client/src/components/timetable/Timetable.tsx
@@ -13,6 +13,7 @@ const StyledTimetable = styled.div`
   display: grid;
   min-height: 700px;
   max-height: 900px;
+  margin-bottom: 20px;
   box-sizing: content-box;
   grid-gap: ${1 / devicePixelRatio}px;
   grid-template: auto repeat(${rows}, 1fr) / auto repeat(${days.length}, 1fr);

--- a/client/src/components/timetable/Timetable.tsx
+++ b/client/src/components/timetable/Timetable.tsx
@@ -7,13 +7,15 @@ import { ClassDropzones } from './ClassDropzones'
 import { DroppedClasses } from './DroppedClasses'
 import * as theme from '../../constants/theme'
 
-const rows: number = hoursRange[1] - hoursRange[0] + 2
+const rows: number = hoursRange[1] - hoursRange[0] + 1
 
 const StyledTimetable = styled.div`
   display: grid;
+  min-height: 400px;
+  max-height: 800px;
   box-sizing: content-box;
   grid-gap: ${1 / devicePixelRatio}px;
-  grid-template: repeat(${rows}, calc(100% / ${rows})) / auto repeat(${days.length}, 1fr);
+  grid-template: auto repeat(${rows}, 1fr) / auto repeat(${days.length}, 1fr);
   border: 1px solid ${theme.border};
   border-radius: 6px;
   overflow: hidden;

--- a/client/src/components/timetable/Timetable.tsx
+++ b/client/src/components/timetable/Timetable.tsx
@@ -11,8 +11,8 @@ const rows: number = hoursRange[1] - hoursRange[0] + 1
 
 const StyledTimetable = styled.div`
   display: grid;
-  min-height: 400px;
-  max-height: 800px;
+  min-height: 700px;
+  max-height: 900px;
   box-sizing: content-box;
   grid-gap: ${1 / devicePixelRatio}px;
   grid-template: auto repeat(${rows}, 1fr) / auto repeat(${days.length}, 1fr);

--- a/client/src/components/timetable/Timetable.tsx
+++ b/client/src/components/timetable/Timetable.tsx
@@ -19,13 +19,6 @@ const StyledTimetable = styled.div`
   overflow: hidden;
 `
 
-const BorderTable = styled.table`
-  border: 1px solid red;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-`
-
 interface TimetableProps {
   selectedCourses: CourseData[]
   selectedClassIds: string[]

--- a/client/src/components/timetable/Timetable.tsx
+++ b/client/src/components/timetable/Timetable.tsx
@@ -5,15 +5,25 @@ import { days, hoursRange } from '../../constants/timetable'
 import { TimetableLayout } from './TimetableLayout'
 import { ClassDropzones } from './ClassDropzones'
 import { DroppedClasses } from './DroppedClasses'
+import * as theme from '../../constants/theme'
 
 const rows: number = hoursRange[1] - hoursRange[0] + 2
 
 const StyledTimetable = styled.div`
   display: grid;
+  box-sizing: content-box;
+  grid-gap: ${1 / devicePixelRatio}px;
   grid-template: repeat(${rows}, calc(100% / ${rows})) / auto repeat(${days.length}, 1fr);
-  border: 3px solid;
-  border-color: rgba(0, 0, 0, 0.2);
-  box-sizing: border-box;
+  border: 1px solid ${theme.border};
+  border-radius: 6px;
+  overflow: hidden;
+`
+
+const BorderTable = styled.table`
+  border: 1px solid red;
+  position: absolute;
+  width: 100%;
+  height: 100%;
 `
 
 interface TimetableProps {

--- a/client/src/components/timetable/TimetableLayout.tsx
+++ b/client/src/components/timetable/TimetableLayout.tsx
@@ -1,10 +1,12 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components'
+import * as theme from '../../constants/theme'
 
 const BaseCell = styled.div<{ x: number; y: number }>`
   grid-column: ${props => props.x};
   grid-row: ${props => props.y};
-  border: 0.2px solid rgba(0, 0, 0, 0.2);
+  // border: 1px solid red;
+  box-shadow: 0 0 0 ${1 / devicePixelRatio}px ${theme.border};
 
   display: inline-flex;
   align-items: center;
@@ -23,14 +25,14 @@ const HourCell = styled(BaseCell)`
 `
 
 const Is12HourModeToggle = styled.span`
-  color: #3a76f8;
+  color: ${theme.primary};
   font-weight: bold;
   cursor: pointer;
   user-select: none;
   transition: color 100ms;
 
   &:hover {
-    color: #084cdd;
+    color: ${theme.primaryDark};
   }
 `
 

--- a/client/src/components/timetable/TimetableLayout.tsx
+++ b/client/src/components/timetable/TimetableLayout.tsx
@@ -2,10 +2,11 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components'
 import * as theme from '../../constants/theme'
 
+const headerPadding: number = 15
+
 const BaseCell = styled.div<{ x: number; y: number }>`
   grid-column: ${props => props.x};
   grid-row: ${props => props.y};
-  // border: 1px solid red;
   box-shadow: 0 0 0 ${1 / devicePixelRatio}px ${theme.border};
 
   display: inline-flex;
@@ -13,8 +14,12 @@ const BaseCell = styled.div<{ x: number; y: number }>`
   justify-content: center;
 `
 
+const DayCell = styled(BaseCell)`
+  padding: ${headerPadding}px 0;
+`
+
 const HourCell = styled(BaseCell)`
-  padding: 0 25px 0 25px;
+  padding: 0 ${headerPadding}px;
   display: grid;
   justify-content: end;
 
@@ -73,9 +78,9 @@ const TimetableLayout: FunctionComponent<TimetableLayoutProps> = ({
   const hours: string[] = generateHours(hoursRange, is12HourMode)
 
   const dayCells = days.map((day, i) => (
-    <BaseCell key={day} x={i + 2} y={1}>
+    <DayCell key={day} x={i + 2} y={1}>
       {day}
-    </BaseCell>
+    </DayCell>
   ))
 
   const hourCells = hours.map((hour, i) => (

--- a/client/src/constants/theme.ts
+++ b/client/src/constants/theme.ts
@@ -1,0 +1,3 @@
+export const primary: string = '#3a76f8' // CSESoc color
+export const primaryDark: string = '#084cdd' // darker variation
+export const border: string = '#bbb' // darker variation

--- a/client/src/constants/theme.ts
+++ b/client/src/constants/theme.ts
@@ -1,3 +1,3 @@
 export const primary: string = '#3a76f8' // CSESoc color
 export const primaryDark: string = '#084cdd' // darker variation
-export const border: string = '#bbb' // darker variation
+export const border: string = '#bbb' // border for timetable, select, etc.

--- a/client/src/constants/timetable.ts
+++ b/client/src/constants/timetable.ts
@@ -1,11 +1,11 @@
-export const colours: string[] = [
-  'violet',
-  'indigo',
-  'blue',
-  'green',
-  'yellow',
-  'orange',
-  'red',
+import * as theme from './theme'
+
+export const colors: string[] = [
+  theme.primary,
+  '#00796b', // green
+  '#aa00ff', // purple
+  '#3f51b5', // blue
+  '#bc5100', // red
 ]
 
 export const days: string[] = [

--- a/client/src/hooks/useColorMapper.ts
+++ b/client/src/hooks/useColorMapper.ts
@@ -1,41 +1,43 @@
 import { useState, useEffect } from 'react'
-import { colours } from '../constants/timetable'
+import { colors } from '../constants/timetable'
+
+const defaultColor = colors[colors.length - 1]
 
 /**
  * Assigns a unique color, chosen from a set of fixed colors, to each course code
- * 
+ *
  * @param courseCodes An array containing course codes
  * @return An object that maps a color to each course code
- * 
+ *
  * @example
  * const assignedColors = useColorMapper(selectedCourses.map(course => course.courseCode))
  */
 export const useColorMapper = (courseCodes: string[]): Record<string, string> => {
-  const [assignedColours, setAssignedColours] = useState<
+  const [assignedColors, setAssignedColors] = useState<
     Record<string, string>
   >({})
 
   useEffect(() => {
     const takenColors = new Set<string>()
-    const newAssignedColours: Record<string, string> = {}
-    
+    const newAssignedColors: Record<string, string> = {}
+
     courseCodes.forEach(item => {
       const color =
-        item in assignedColours
-          ? assignedColours[item]
-          : colours.find(c => !takenColors.has(c))
-      newAssignedColours[item] = color || 'orange'
+        item in assignedColors
+          ? assignedColors[item]
+          : colors.find(c => !takenColors.has(c))
+      newAssignedColors[item] = color || defaultColor
       if (color) {
         takenColors.add(color)
       }
     })
 
     if (
-      JSON.stringify(assignedColours) !== JSON.stringify(newAssignedColours)
+      JSON.stringify(assignedColors) !== JSON.stringify(newAssignedColors)
     ) {
-      setAssignedColours(newAssignedColours)
+      setAssignedColors(newAssignedColors)
     }
   }, [courseCodes])
 
-  return assignedColours
+  return assignedColors
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,8 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Roboto', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/client/src/interfaces/CourseData.tsx
+++ b/client/src/interfaces/CourseData.tsx
@@ -13,6 +13,7 @@ export interface ClassData {
 export interface Period {
   time: ClassTime
   location: string
+  locationShort: string
 }
 
 export interface ClassTime {

--- a/client/src/interfaces/DbCourse.tsx
+++ b/client/src/interfaces/DbCourse.tsx
@@ -27,30 +27,31 @@ export interface DbTime {
 
 /**
  * An adapter that formats a DBTimes object to a Period object
- * 
+ *
  * @param dbTimes A DBTimes object
  * @return A Period object which is converted from the DBTimes object
- * 
+ *
  * @example
  * const periods = dbClass.times.map(dbTimesToPeriod)
  */
 const dbTimesToPeriod = (dbTimes: DbTimes): Period => {
   return {
     location: dbTimes.location,
+    locationShort: locationShorten(dbTimes.location),
     time: {
       day: dbTimes.day,
       start: dbTimes.time.start,
       end: dbTimes.time.end,
-    },
+    }
   }
 }
 
 /**
- * An adapter that formats a DBCourse object to a CourseData object 
- * 
+ * An adapter that formats a DBCourse object to a CourseData object
+ *
  * @param dbCourse A DBCourse object
  * @return A CourseData object
- * 
+ *
  * @example
  * const data = await fetch(`${baseURL}/courses/${courseCode}/`)
  * const json: DBCourse = await data.json()
@@ -62,7 +63,7 @@ export const dbCourseToCourseData = (dbCourse: DbCourse): CourseData => {
     const classData: ClassData = {
       classId: `${dbCourse.courseCode}-${dbClass.activity}-${index}`,
       periods: dbClass.times.map(dbTimesToPeriod),
-      activity: dbClass.activity,
+      activity: dbClass.activity
     }
     if (!(dbClass.activity in classes)) {
       classes[dbClass.activity] = []
@@ -76,3 +77,5 @@ export const dbCourseToCourseData = (dbCourse: DbCourse): CourseData => {
     classes,
   }
 }
+
+const locationShorten = (location: string): string => location.split(" (")[0]


### PR DESCRIPTION
This PR adds the material theme primarily to the timetable. Summary of changes:

- Using the material Card class to represent classes.
- Border radius and padding added to classes.
- Changed the style of dropzones to be semi-transparent cards without text. I think this doesn't look as good as it could yet, but making it better might involve changing the dnd dropzone logic which I don't want to do in this PR.
- Changed to material colours for courses (taken from the canonical [material website](https://material.io/resources/color)). All these colours are dark enough so they can all have white text on top of them (for consistency). I'm really bad at choosing colours, so I welcome anyone coming up with a better set.
- Applied the standard material font (Roboto) to the whole page. This PR is meant to just be for the timetable, but it seems like we want everything to use Roboto, and specifying the font for each component individually seems unnecessary.
- Made a central theme file with the colours that are used in multiple places (e.g. primary colour).
- Border radius added to the timetable.
- Changed the timetable borders to be more subtle. The outer-border is now consistent with the inner-borders, and there's no doubling up so everything is 1 px. Also ensuring that it renders fine on retina / high res displays in Chrome, with device pixel ratio detection (this is a quirk in Chrome to do with the sharpness of drop shadows on high res displays).
- I didn't want to touch the inventory much, although I made one change to the font colour for readability, but everything else should be the same.