### PR TITLE
bugfix/81-client-allows-duplicated-course-selections

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -73,10 +73,11 @@ const App: FunctionComponent = () => {
   }, [isDarkMode]);
 
   const handleSelectCourse = async (e: CourseOption) => {
-    const selectedCourseClasses = await getCourseInfo('2020', 'T2', e.value);
-
-    if (selectedCourseClasses) {
-      setSelectedCourses([...selectedCourses, selectedCourseClasses]);
+    if (selectedCourses.filter(course => course.courseCode == e.value).length == 0) {
+      const selectedCourseClasses = await getCourseInfo('2020', 'T2', e.value);
+      if (selectedCourseClasses) {
+        setSelectedCourses([...selectedCourses, selectedCourseClasses]);
+      }
     }
   };
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -73,7 +73,7 @@ const App: FunctionComponent = () => {
   }, [isDarkMode]);
 
   const handleSelectCourse = async (e: CourseOption) => {
-    if (selectedCourses.filter(course => course.courseCode == e.value).length == 0) {
+    if (selectedCourses.find(course => course.courseCode === e.value) === undefined) {
       const selectedCourseClasses = await getCourseInfo('2020', 'T2', e.value);
       if (selectedCourseClasses) {
         setSelectedCourses([...selectedCourses, selectedCourseClasses]);


### PR DESCRIPTION
Fixed the bug by checking if the course code is already in the list of selected courses before adding it to the list of selected courses.