### PR TITLE
Hotfix/203 fix scraper crash

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -156,7 +156,7 @@ const App: FunctionComponent = () => {
     const codes: string[] = Array.isArray(data) ? data : [data];
     try {
       Promise.all(
-        codes.map((code) => getCourseInfo('2020', 'T3', code)),
+        codes.map((code) => getCourseInfo('2021', 'T1', code)),
       ).then((result) => {
         const addedCourses = result as CourseData[];
         const newSelectedCourses = [...selectedCourses, ...addedCourses];

--- a/client/src/components/CourseSelect.tsx
+++ b/client/src/components/CourseSelect.tsx
@@ -238,7 +238,7 @@ const CourseSelect: React.FC<CourseSelectProps> = React.memo(({
 
   const fetchCoursesList = async () => {
     try {
-      const fetchedCoursesList = await getCoursesList('2020', 'T3');
+      const fetchedCoursesList = await getCoursesList('2021', 'T1');
       setCoursesList(fetchedCoursesList);
       checkExternallyAdded();
       fuzzy = new Fuse(fetchedCoursesList, searchOptions);

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxtst6 libxss1 \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR
- Adds some missing dependencies to the scraper Dockerfile which were causing the scraper to crash at startup
- Bumps term from 2020 T3 to 2021 T1