### PR TITLE
Feature/ntgl 261 settings modal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -128,6 +128,7 @@ const App: React.FC = () => {
   const [isSquareEdges, setIsSquareEdges] = useState<boolean>(storage.get('isSquareEdges'));
   const [isHideFullClasses, setIsHideFullClasses] = useState<boolean>(storage.get('isHideFullClasses'));
   const [isDefaultUnscheduled, setIsDefaultUnscheduled] = useState<boolean>(storage.get('isDefaultUnscheduled'));
+  const [isHideClassInfo, setIsHideClassInfo] = useState<boolean>(storage.get('isHideClassInfo'));
   const [lastUpdated, setLastUpdated] = useState(0);
 
   if (infoVisibility) {
@@ -276,6 +277,10 @@ const App: React.FC = () => {
     storage.set('isDefaultUnscheduled', isDefaultUnscheduled);
   }, [isDefaultUnscheduled])
 
+  useEffect(() => {
+    storage.set('isHideClassInfo', isHideClassInfo);
+  }, [isHideClassInfo])
+
   type ClassId = string;
   type SavedClasses = Record<CourseCode, Record<Activity, ClassId | InInventory>>;
 
@@ -357,6 +362,8 @@ const App: React.FC = () => {
             setIsHideFullClasses={setIsHideFullClasses}
             isDefaultUnscheduled={isDefaultUnscheduled}
             setIsDefaultUnscheduled={setIsDefaultUnscheduled}
+            isHideClassInfo={isHideClassInfo}
+            setIsHideClassInfo={setIsHideClassInfo}
           />
           {isPreview && (
             <FriendsDrawer isFriendsListOpen={isFriendsListOpen} isLoggedIn={isLoggedIn} setIsLoggedIn={handleSetIsLoggedIn} />
@@ -392,6 +399,7 @@ const App: React.FC = () => {
                 clashes={checkClashes()}
                 setInfoVisibility={setInfoVisibility}
                 isHideFullClasses={isHideFullClasses}
+                isHideClassInfo={isHideClassInfo}
               />
               <Footer>
                 While we try our best, Notangles is not an official UNSW site, and cannot guarantee data accuracy or reliability.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -171,7 +171,9 @@ const App: React.FC = () => {
 
         Object.keys(course.activities).forEach((activity) => {
           // temp until auto timetabling works
-          [prev[course.code][activity]] = isDefaultUnscheduled ? [null] : course.activities[activity]; // null for unscheduled
+          prev[course.code][activity] = isDefaultUnscheduled
+            ? null
+            : (course.activities[activity].find((x) => x.enrolments != x.capacity) ?? null); // null for unscheduled
         });
 
         return prev;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -340,6 +340,8 @@ const App: React.FC = () => {
             handleDrawerOpen={handleDrawerOpen}
             isSquareEdges={isSquareEdges}
             setIsSquareEdges={setIsSquareEdges}
+            is12HourMode={is12HourMode}
+            setIs12HourMode={setIs12HourMode}
           />
           {isPreview && (
             <FriendsDrawer isFriendsListOpen={isFriendsListOpen} isLoggedIn={isLoggedIn} setIsLoggedIn={handleSetIsLoggedIn} />

--- a/client/src/components/CourseSelect.tsx
+++ b/client/src/components/CourseSelect.tsx
@@ -114,16 +114,17 @@ const StyledUl = styled.ul`
 interface CourseSelectProps {
   selectedCourses: CourseData[];
   assignedColors: Record<string, string>;
-  handleSelect(data: string | string[]): void;
+  handleSelect(data: string | string[], a?: boolean, callback?: (_selectedCourses: CourseData[]) => void, isDefaultUnscheduled?: boolean): void;
   handleRemove(courseCode: string): void;
   setErrorMsg(errorMsg: string): void;
   setErrorVisibility(visibility: boolean): void;
   setLastUpdated(date: number): void;
+  isDefaultUnscheduled: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
 const CourseSelect: React.FC<CourseSelectProps> = React.memo(
-  ({ selectedCourses, assignedColors, handleSelect, handleRemove, setErrorMsg, setErrorVisibility, setLastUpdated }) => {
+  ({ selectedCourses, assignedColors, handleSelect, handleRemove, setErrorMsg, setErrorVisibility, setLastUpdated, isDefaultUnscheduled }) => {
     const [coursesList, setCoursesList] = useState<CoursesList>([]);
     const [options, setOptionsState] = useState<CoursesList>([]);
     const [inputValue, setInputValue] = useState<string>('');
@@ -212,7 +213,7 @@ const CourseSelect: React.FC<CourseSelectProps> = React.memo(
           return;
         }
       } else {
-        handleSelect(added.map((course) => course.code));
+        handleSelect(added.map((course) => course.code), undefined, undefined, isDefaultUnscheduled);
         setSelectedValue([...selectedValue, ...(added as CourseOverview[])]);
       }
 
@@ -385,7 +386,8 @@ const CourseSelect: React.FC<CourseSelectProps> = React.memo(
     !(
       prev.selectedCourses.length !== next.selectedCourses.length ||
       prev.selectedCourses.some((course, i) => course.code !== next.selectedCourses[i].code) ||
-      JSON.stringify(prev.assignedColors) !== JSON.stringify(next.assignedColors)
+      JSON.stringify(prev.assignedColors) !== JSON.stringify(next.assignedColors) ||
+      prev.isDefaultUnscheduled !== next.isDefaultUnscheduled
     )
 );
 

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -66,6 +66,8 @@ interface NavBarProps {
   isHideFullClasses: boolean,
   setIsDefaultUnscheduled(mode: boolean): void;
   isDefaultUnscheduled: boolean;
+  setIsHideClassInfo(mode: boolean): void;
+  isHideClassInfo: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
@@ -81,6 +83,8 @@ const Navbar: React.FC<NavBarProps> = ({
   isHideFullClasses,
   setIsDefaultUnscheduled,
   isDefaultUnscheduled,
+  setIsHideClassInfo,
+  isHideClassInfo,
 }) => {
   const theme = useTheme<ThemeType>();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -116,6 +120,8 @@ const Navbar: React.FC<NavBarProps> = ({
               setIsHideFullClasses={setIsHideFullClasses}
               isDefaultUnscheduled={isDefaultUnscheduled}
               setIsDefaultUnscheduled={setIsDefaultUnscheduled}
+              isHideClassInfo={isHideClassInfo}
+              setIsHideClassInfo={setIsHideClassInfo}
             />
           </Toolbar>
         </StyledNavBar>

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -75,10 +75,12 @@ interface NavBarProps {
   handleDrawerOpen(): void;
   setIsSquareEdges(mode: boolean): void;
   isSquareEdges: boolean;
+  setIs12HourMode(mode: boolean): void;
+  is12HourMode: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
-const Navbar: React.FC<NavBarProps> = ({ setIsDarkMode, isDarkMode, handleDrawerOpen, setIsSquareEdges, isSquareEdges }) => {
+const Navbar: React.FC<NavBarProps> = ({ setIsDarkMode, isDarkMode, handleDrawerOpen, setIsSquareEdges, isSquareEdges, setIs12HourMode, is12HourMode }) => {
   const theme = useTheme<ThemeType>();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -113,7 +115,14 @@ const Navbar: React.FC<NavBarProps> = ({ setIsDarkMode, isDarkMode, handleDrawer
               </DarkModeButton>
             </Tooltip>
             <About />
-            <Settings isSquareEdges={isSquareEdges} setIsSquareEdges={setIsSquareEdges} />
+            <Settings
+              isSquareEdges={isSquareEdges}
+              setIsSquareEdges={setIsSquareEdges}
+              isDarkMode={isDarkMode}
+              setIsDarkMode={setIsDarkMode}
+              is12HourMode={is12HourMode}
+              setIs12HourMode={setIs12HourMode}
+            />
           </Toolbar>
         </StyledNavBar>
       </NavbarBox>

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -77,10 +77,26 @@ interface NavBarProps {
   isSquareEdges: boolean;
   setIs12HourMode(mode: boolean): void;
   is12HourMode: boolean;
+  setIsHideFullClasses(mode: boolean): void;
+  isHideFullClasses: boolean,
+  setIsDefaultUnscheduled(mode: boolean): void;
+  isDefaultUnscheduled: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
-const Navbar: React.FC<NavBarProps> = ({ setIsDarkMode, isDarkMode, handleDrawerOpen, setIsSquareEdges, isSquareEdges, setIs12HourMode, is12HourMode }) => {
+const Navbar: React.FC<NavBarProps> = ({
+  setIsDarkMode,
+  isDarkMode,
+  handleDrawerOpen,
+  setIsSquareEdges,
+  isSquareEdges,
+  setIs12HourMode,
+  is12HourMode,
+  setIsHideFullClasses,
+  isHideFullClasses,
+  setIsDefaultUnscheduled,
+  isDefaultUnscheduled,
+}) => {
   const theme = useTheme<ThemeType>();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -122,6 +138,10 @@ const Navbar: React.FC<NavBarProps> = ({ setIsDarkMode, isDarkMode, handleDrawer
               setIsDarkMode={setIsDarkMode}
               is12HourMode={is12HourMode}
               setIs12HourMode={setIs12HourMode}
+              isHideFullClasses={isHideFullClasses}
+              setIsHideFullClasses={setIsHideFullClasses}
+              isDefaultUnscheduled={isDefaultUnscheduled}
+              setIsDefaultUnscheduled={setIsDefaultUnscheduled}
             />
           </Toolbar>
         </StyledNavBar>

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -7,11 +7,8 @@ import { useMediaQuery } from '@material-ui/core';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import ToggleButton from '@material-ui/lab/ToggleButton';
-import Brightness2Icon from '@material-ui/icons/Brightness2';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
-import Tooltip from '@material-ui/core/Tooltip';
 import { ThemeType } from '../constants/theme';
 
 import About from './About';
@@ -34,18 +31,6 @@ const StyledNavBar = styled(AppBar)`
 `;
 const NavbarTitle = styled(Typography)`
   flex-grow: 1;
-`;
-
-const DarkModeButton = styled(ToggleButton)`
-  border: none;
-  border-radius: 40px;
-  margin-right: 5px;
-  width: 40px;
-  height: 40px;
-`;
-const DarkModeIcon = styled(Brightness2Icon)`
-  transform: rotate(180deg);
-  color: #bde0ff;
 `;
 
 const Weak = styled.span`
@@ -119,17 +104,6 @@ const Navbar: React.FC<NavBarProps> = ({
               </Weak>
             </NavbarTitle>
 
-            <Tooltip title="Toggle dark mode">
-              <DarkModeButton
-                value={isDarkMode}
-                selected={isDarkMode}
-                onChange={() => {
-                  setIsDarkMode(!isDarkMode);
-                }}
-              >
-                <DarkModeIcon fontSize="small" />
-              </DarkModeButton>
-            </Tooltip>
             <About />
             <Settings
               isSquareEdges={isSquareEdges}

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -10,7 +10,7 @@ import Typography from '@material-ui/core/Typography';
 import Tooltip from '@material-ui/core/Tooltip';
 import Switch from '@material-ui/core/Switch';
 import Divider from '@material-ui/core/Divider';
-import { List, ListItem } from '@material-ui/core';
+import { List, ListItem, ListItemText } from '@material-ui/core';
 
 const StyledDialogTitle = styled(MuiDialogTitle)`
   margin: 0;
@@ -24,7 +24,16 @@ const CloseButton = styled(IconButton)`
 `;
 
 const SettingsList = styled(List)`
-  padding: 0;
+  padding: 0 0 0 10px;
+`;
+
+const SettingText = styled(ListItemText)`
+  padding: 5px 0 5px 0;
+`;
+
+const StyledSwitch = styled(Switch)`
+  position: absolute;
+  right: 10px
 `;
 
 interface SettingsProps {
@@ -67,10 +76,10 @@ const Settings: React.FC<SettingsProps> = React.memo(
     const settingsToggles: { state: boolean; setter: (mode: boolean) => void; desc: string }[] = [
       { state: isDarkMode, setter: setIsDarkMode, desc: 'Dark mode' },
       { state: isSquareEdges, setter: setIsSquareEdges, desc: 'Square corners on classes' },
-      { state: is12HourMode, setter: setIs12HourMode, desc: 'Display times in 12-hour format' },
-      { state: isHideFullClasses, setter: setIsHideFullClasses, desc: 'Hide classes that are at full capacity' },
-      { state: isDefaultUnscheduled, setter: setIsDefaultUnscheduled, desc: 'Send newly added classes to Unscheduled by default' },
-      { state: isHideClassInfo, setter: setIsHideClassInfo, desc: 'Hide detailed class information' },
+      { state: is12HourMode, setter: setIs12HourMode, desc: '12-hour time' },
+      { state: isHideFullClasses, setter: setIsHideFullClasses, desc: 'Hide full classes' },
+      { state: isDefaultUnscheduled, setter: setIsDefaultUnscheduled, desc: 'Unschedule classes by default' },
+      { state: isHideClassInfo, setter: setIsHideClassInfo, desc: 'Hide class details' },
     ];
 
     const settings = settingsToggles.map((setting) => {
@@ -78,15 +87,15 @@ const Settings: React.FC<SettingsProps> = React.memo(
         <>
           <Divider />
           <ListItem>
-            <Switch
+            <SettingText primary={setting['desc']} />
+            <StyledSwitch
               value={setting['state']}
               checked={setting['state']}
               color="primary"
               onChange={() => {
                 setting['setter'](!setting['state']);
               }}
-            />
-            {setting['desc']}
+            /> 
           </ListItem>
         </>
       );

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -11,6 +11,7 @@ import Typography from '@material-ui/core/Typography';
 import Tooltip from '@material-ui/core/Tooltip';
 import Switch from '@material-ui/core/Switch';
 import Divider from '@material-ui/core/Divider';
+import { List, ListItem } from '@material-ui/core';
 
 const StyledDialogTitle = styled(MuiDialogTitle)`
   margin: 0;
@@ -27,17 +28,42 @@ const DialogContent = styled(MuiDialogContent)`
 `;
 
 interface SettingsProps {
+  setIsDarkMode(mode: boolean): void;
+  isDarkMode: boolean;
   setIsSquareEdges(mode: boolean): void;
   isSquareEdges: boolean;
+  setIs12HourMode(mode: boolean): void;
+  is12HourMode: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
-const Settings: React.FC<SettingsProps> = React.memo(({ isSquareEdges, setIsSquareEdges }) => {
+const Settings: React.FC<SettingsProps> = React.memo(({ setIsDarkMode, isDarkMode, setIsSquareEdges, isSquareEdges, setIs12HourMode, is12HourMode }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   const toggleIsOpen = () => {
     setIsOpen(!isOpen);
   };
+
+  const settingsToggles: {state: boolean, setter: (mode: boolean) => void, desc: string}[] = [
+    {state: isDarkMode, setter: setIsDarkMode, desc: 'Dark Mode'},
+    {state: isSquareEdges, setter: setIsSquareEdges, desc: 'Square corners on classes'},
+    {state: is12HourMode, setter: setIs12HourMode, desc: 'Display Times in 12-hour format'},
+  ]
+
+  const settings = settingsToggles.map((e) => {
+    return (<div><Divider /> 
+      <DialogContent>
+        <Switch
+      value={e['state']}
+      checked={e['state']}
+      color="primary"
+      onChange={() => {
+        e['setter'](!e['state']);
+      }}
+      />
+          {e['desc']}
+      </DialogContent></div>)
+    })
 
   return (
     <div>
@@ -60,20 +86,7 @@ const Settings: React.FC<SettingsProps> = React.memo(({ isSquareEdges, setIsSqua
             <CloseIcon />
           </CloseButton>
         </StyledDialogTitle>
-        <Divider />
-        <DialogContent>
-          <Typography variant="body1">
-            <Switch
-              value={isSquareEdges}
-              checked={isSquareEdges}
-              color="primary"
-              onChange={() => {
-                setIsSquareEdges(!isSquareEdges);
-              }}
-            />
-            Square corners on classes
-          </Typography>
-        </DialogContent>
+        <Typography variant="body1">{settings}</Typography>
       </Dialog>
     </div>
   );

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -38,6 +38,8 @@ interface SettingsProps {
   isHideFullClasses: boolean,
   setIsDefaultUnscheduled(mode: boolean): void;
   isDefaultUnscheduled: boolean;
+  setIsHideClassInfo(mode: boolean): void;
+  isHideClassInfo: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
@@ -53,6 +55,8 @@ const Settings: React.FC<SettingsProps> = React.memo(
     isHideFullClasses,
     setIsDefaultUnscheduled,
     isDefaultUnscheduled,
+    setIsHideClassInfo,
+    isHideClassInfo,
   }) => {
     const [isOpen, setIsOpen] = React.useState(false);
 
@@ -65,24 +69,25 @@ const Settings: React.FC<SettingsProps> = React.memo(
       { state: isSquareEdges, setter: setIsSquareEdges, desc: 'Square corners on classes' },
       { state: is12HourMode, setter: setIs12HourMode, desc: 'Display Times in 12-hour format' },
       { state: isHideFullClasses, setter: setIsHideFullClasses, desc: 'Hide classes that are at full capacity' },
-      { state: isDefaultUnscheduled, setter: setIsDefaultUnscheduled, desc: 'Send newly added classes to Unscheduled by default' }
+      { state: isDefaultUnscheduled, setter: setIsDefaultUnscheduled, desc: 'Send newly added classes to Unscheduled by default' },
+      { state: isHideClassInfo, setter: setIsHideClassInfo, desc: 'Hide class information' },
     ];
 
     const settings = settingsToggles.map((e) => {
       return (
         <>
           <Divider />
-            <ListItem>
-              <Switch
-                value={e['state']}
-                checked={e['state']}
-                color="primary"
-                onChange={() => {
-                  e['setter'](!e['state']);
-                }}
-              />
-              {e['desc']}
-            </ListItem>
+          <ListItem>
+            <Switch
+              value={e['state']}
+              checked={e['state']}
+              color="primary"
+              onChange={() => {
+                e['setter'](!e['state']);
+              }}
+            />
+            {e['desc']}
+          </ListItem>
         </>
       );
     });

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 import Dialog from '@material-ui/core/Dialog';
 import MuiDialogTitle from '@material-ui/core/DialogTitle';
-import MuiDialogContent from '@material-ui/core/DialogContent';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import SettingsIcon from '@material-ui/icons/Settings';
@@ -23,8 +22,9 @@ const CloseButton = styled(IconButton)`
   right: 10px;
   top: 10px;
 `;
-const DialogContent = styled(MuiDialogContent)`
-  padding: 20px;
+
+const SettingsList = styled(List)`
+  padding: 0;
 `;
 
 interface SettingsProps {
@@ -72,17 +72,17 @@ const Settings: React.FC<SettingsProps> = React.memo(
       return (
         <>
           <Divider />
-          <DialogContent>
-            <Switch
-              value={e['state']}
-              checked={e['state']}
-              color="primary"
-              onChange={() => {
-                e['setter'](!e['state']);
-              }}
-            />
-            {e['desc']}
-          </DialogContent>
+            <ListItem>
+              <Switch
+                value={e['state']}
+                checked={e['state']}
+                color="primary"
+                onChange={() => {
+                  e['setter'](!e['state']);
+                }}
+              />
+              {e['desc']}
+            </ListItem>
         </>
       );
     });
@@ -108,7 +108,9 @@ const Settings: React.FC<SettingsProps> = React.memo(
               <CloseIcon />
             </CloseButton>
           </StyledDialogTitle>
-          <Typography variant="body1">{settings}</Typography>
+          <Typography variant="body1">
+            <SettingsList>{settings}</SettingsList>
+          </Typography>
         </Dialog>
       </div>
     );

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -65,28 +65,28 @@ const Settings: React.FC<SettingsProps> = React.memo(
     };
 
     const settingsToggles: { state: boolean; setter: (mode: boolean) => void; desc: string }[] = [
-      { state: isDarkMode, setter: setIsDarkMode, desc: 'Dark Mode' },
+      { state: isDarkMode, setter: setIsDarkMode, desc: 'Dark mode' },
       { state: isSquareEdges, setter: setIsSquareEdges, desc: 'Square corners on classes' },
-      { state: is12HourMode, setter: setIs12HourMode, desc: 'Display Times in 12-hour format' },
+      { state: is12HourMode, setter: setIs12HourMode, desc: 'Display times in 12-hour format' },
       { state: isHideFullClasses, setter: setIsHideFullClasses, desc: 'Hide classes that are at full capacity' },
       { state: isDefaultUnscheduled, setter: setIsDefaultUnscheduled, desc: 'Send newly added classes to Unscheduled by default' },
-      { state: isHideClassInfo, setter: setIsHideClassInfo, desc: 'Hide class information' },
+      { state: isHideClassInfo, setter: setIsHideClassInfo, desc: 'Hide detailed class information' },
     ];
 
-    const settings = settingsToggles.map((e) => {
+    const settings = settingsToggles.map((setting) => {
       return (
         <>
           <Divider />
           <ListItem>
             <Switch
-              value={e['state']}
-              checked={e['state']}
+              value={setting['state']}
+              checked={setting['state']}
               color="primary"
               onChange={() => {
-                e['setter'](!e['state']);
+                setting['setter'](!setting['state']);
               }}
             />
-            {e['desc']}
+            {setting['desc']}
           </ListItem>
         </>
       );

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -34,62 +34,85 @@ interface SettingsProps {
   isSquareEdges: boolean;
   setIs12HourMode(mode: boolean): void;
   is12HourMode: boolean;
+  setIsHideFullClasses(mode: boolean): void;
+  isHideFullClasses: boolean,
+  setIsDefaultUnscheduled(mode: boolean): void;
+  isDefaultUnscheduled: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
-const Settings: React.FC<SettingsProps> = React.memo(({ setIsDarkMode, isDarkMode, setIsSquareEdges, isSquareEdges, setIs12HourMode, is12HourMode }) => {
-  const [isOpen, setIsOpen] = React.useState(false);
+const Settings: React.FC<SettingsProps> = React.memo(
+  ({
+    setIsDarkMode,
+    isDarkMode,
+    setIsSquareEdges,
+    isSquareEdges,
+    setIs12HourMode,
+    is12HourMode,
+    setIsHideFullClasses,
+    isHideFullClasses,
+    setIsDefaultUnscheduled,
+    isDefaultUnscheduled,
+  }) => {
+    const [isOpen, setIsOpen] = React.useState(false);
 
-  const toggleIsOpen = () => {
-    setIsOpen(!isOpen);
-  };
+    const toggleIsOpen = () => {
+      setIsOpen(!isOpen);
+    };
 
-  const settingsToggles: {state: boolean, setter: (mode: boolean) => void, desc: string}[] = [
-    {state: isDarkMode, setter: setIsDarkMode, desc: 'Dark Mode'},
-    {state: isSquareEdges, setter: setIsSquareEdges, desc: 'Square corners on classes'},
-    {state: is12HourMode, setter: setIs12HourMode, desc: 'Display Times in 12-hour format'},
-  ]
+    const settingsToggles: { state: boolean; setter: (mode: boolean) => void; desc: string }[] = [
+      { state: isDarkMode, setter: setIsDarkMode, desc: 'Dark Mode' },
+      { state: isSquareEdges, setter: setIsSquareEdges, desc: 'Square corners on classes' },
+      { state: is12HourMode, setter: setIs12HourMode, desc: 'Display Times in 12-hour format' },
+      { state: isHideFullClasses, setter: setIsHideFullClasses, desc: 'Hide classes that are at full capacity' },
+      { state: isDefaultUnscheduled, setter: setIsDefaultUnscheduled, desc: 'Send newly added classes to Unscheduled by default' }
+    ];
 
-  const settings = settingsToggles.map((e) => {
-    return (<div><Divider /> 
-      <DialogContent>
-        <Switch
-      value={e['state']}
-      checked={e['state']}
-      color="primary"
-      onChange={() => {
-        e['setter'](!e['state']);
-      }}
-      />
-          {e['desc']}
-      </DialogContent></div>)
-    })
+    const settings = settingsToggles.map((e) => {
+      return (
+        <>
+          <Divider />
+          <DialogContent>
+            <Switch
+              value={e['state']}
+              checked={e['state']}
+              color="primary"
+              onChange={() => {
+                e['setter'](!e['state']);
+              }}
+            />
+            {e['desc']}
+          </DialogContent>
+        </>
+      );
+    });
 
-  return (
-    <div>
-      <Tooltip title="Settings">
-        <IconButton color="inherit" onClick={toggleIsOpen}>
-          <SettingsIcon />
-        </IconButton>
-      </Tooltip>
-      <Dialog
-        disableScrollLock
-        onClose={toggleIsOpen}
-        aria-labelledby="customized-dialog-title"
-        open={isOpen}
-        fullWidth
-        maxWidth="sm"
-      >
-        <StyledDialogTitle disableTypography>
-          <Typography variant="h5">Settings</Typography>
-          <CloseButton aria-label="close" onClick={toggleIsOpen}>
-            <CloseIcon />
-          </CloseButton>
-        </StyledDialogTitle>
-        <Typography variant="body1">{settings}</Typography>
-      </Dialog>
-    </div>
-  );
-});
+    return (
+      <div>
+        <Tooltip title="Settings">
+          <IconButton color="inherit" onClick={toggleIsOpen}>
+            <SettingsIcon />
+          </IconButton>
+        </Tooltip>
+        <Dialog
+          disableScrollLock
+          onClose={toggleIsOpen}
+          aria-labelledby="customized-dialog-title"
+          open={isOpen}
+          fullWidth
+          maxWidth="sm"
+        >
+          <StyledDialogTitle disableTypography>
+            <Typography variant="h5">Settings</Typography>
+            <CloseButton aria-label="close" onClick={toggleIsOpen}>
+              <CloseIcon />
+            </CloseButton>
+          </StyledDialogTitle>
+          <Typography variant="body1">{settings}</Typography>
+        </Dialog>
+      </div>
+    );
+  }
+);
 
 export default Settings;

--- a/client/src/components/timetable/DroppedClasses.tsx
+++ b/client/src/components/timetable/DroppedClasses.tsx
@@ -183,11 +183,12 @@ interface DroppedClassProps {
   hasClash: boolean;
   isSquareEdges: boolean;
   setInfoVisibility(value: boolean): void;
+  isHideClassInfo: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
 const DroppedClass: React.FC<DroppedClassProps> = React.memo(
-  ({ cardData, color, days, y, earliestStartTime, hasClash, isSquareEdges, setInfoVisibility }) => {
+  ({ cardData, color, days, y, earliestStartTime, hasClash, isSquareEdges, setInfoVisibility, isHideClassInfo }) => { 
     const element = useRef<HTMLDivElement>(null);
     const rippleRef = useRef<any>(null);
 
@@ -279,7 +280,7 @@ const DroppedClass: React.FC<DroppedClassProps> = React.memo(
         ...cardData.class.course.activities[cardData.class.activity].map((classData) => classData.periods.length)
       );
     }
-
+    
     return (
       <StyledCourseClass
         ref={element}
@@ -305,20 +306,24 @@ const DroppedClass: React.FC<DroppedClassProps> = React.memo(
           </p>
           <p style={pStyleSmall}>
             {isPeriod(cardData) ? (
-              <>
-                <PeopleAltIcon fontSize="inherit" style={iconStyle} /> {cardData.class.enrolments}/{cardData.class.capacity} (
-                {cardData.time.weeks.length > 0 ? 'Weeks' : 'Week'} {cardData.time.weeksString}
-                )
-                <br />
-                <LocationOnIcon fontSize="inherit" style={iconStyle} />
-                {cardData.locations[0] + (cardData.locations.length > 1 ? ` + ${cardData.locations.length - 1}` : '')}
-              </>
-            ) : (
+              isHideClassInfo ? (
+                <></>
+              ) : ( 
+                <>
+                  <PeopleAltIcon fontSize="inherit" style={iconStyle} /> {cardData.class.enrolments}/{cardData.class.capacity} (
+                  {cardData.time.weeks.length > 0 ? 'Weeks' : 'Week'} {cardData.time.weeksString}
+                  )
+                  <br />
+                  <LocationOnIcon fontSize="inherit" style={iconStyle} />
+                  {cardData.locations[0] + (cardData.locations.length > 1 ? ` + ${cardData.locations.length - 1}` : '')}
+                </>
+              )
+            ) : ( 
               <>
                 {activityMaxPeriods} class
                 {activityMaxPeriods !== 1 && 'es'}
               </>
-            )}
+            )} 
           </p>
           <TouchRipple ref={rippleRef} />
         </Card>
@@ -338,6 +343,7 @@ interface DroppedClassesProps {
   clashes: Array<ClassPeriod>;
   isSquareEdges: boolean;
   setInfoVisibility(value: boolean): void;
+  isHideClassInfo: boolean;
 }
 
 const DroppedClasses: React.FC<DroppedClassesProps> = ({
@@ -348,6 +354,7 @@ const DroppedClasses: React.FC<DroppedClassesProps> = ({
   clashes,
   isSquareEdges,
   setInfoVisibility,
+  isHideClassInfo,
 }) => {
   const droppedClasses: JSX.Element[] = [];
   const prevCards = useRef<CardData[]>([]);
@@ -411,6 +418,7 @@ const DroppedClasses: React.FC<DroppedClassesProps> = ({
         hasClash={isPeriod(cardData) ? clashes.includes(cardData) : false}
         isSquareEdges={isSquareEdges}
         setInfoVisibility={setInfoVisibility}
+        isHideClassInfo={isHideClassInfo}
       />
     );
 

--- a/client/src/components/timetable/Dropzones.tsx
+++ b/client/src/components/timetable/Dropzones.tsx
@@ -9,11 +9,12 @@ interface ClassDropzoneProps {
   course: CourseData;
   color: string;
   earliestStartTime: number;
+  isHideFullClasses: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
 const DropzoneGroup: React.FC<ClassDropzoneProps> = React.memo(
-  ({ course, color, earliestStartTime }) => {
+  ({ course, color, earliestStartTime, isHideFullClasses }) => {
     // Deep-ish copy of activities (so we can combine duplicates without affecting original)
 
     let newActivities: Record<Activity, ClassData[]> = {};
@@ -51,7 +52,9 @@ const DropzoneGroup: React.FC<ClassDropzoneProps> = React.memo(
     Object.keys(newActivities).forEach((activity) => {
       newActivities[activity] = newActivities[activity].filter(
         // TODO
-        (classData) => classData.periods.length !== 0
+        (classData) =>
+          classData.periods.length !== 0 &&
+          (!isHideFullClasses || (isHideFullClasses && classData.enrolments !== classData.capacity))
       );
     });
 
@@ -75,7 +78,7 @@ const DropzoneGroup: React.FC<ClassDropzoneProps> = React.memo(
     return <>{dropzones}</>;
   },
   (prev, next) =>
-    !(prev.color !== next.color || prev.earliestStartTime !== next.earliestStartTime || prev.course.code !== next.course.code)
+    !(prev.color !== next.color || prev.earliestStartTime !== next.earliestStartTime || prev.course.code !== next.course.code || prev.isHideFullClasses !== next.isHideFullClasses)
 );
 
 interface Theme {
@@ -89,17 +92,19 @@ interface DropzonesProps {
   assignedColors: Record<string, string>;
   earliestStartTime: number;
   theme: Theme;
+  isHideFullClasses: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
 const Dropzones: React.FC<DropzonesProps> = React.memo(
-  ({ selectedCourses, assignedColors, earliestStartTime, theme }) => {
+  ({ selectedCourses, assignedColors, earliestStartTime, theme, isHideFullClasses }) => {
     const dropzones = selectedCourses.map((course) => (
       <DropzoneGroup
         key={course.code}
         course={course}
         color={assignedColors[course.code]}
         earliestStartTime={earliestStartTime}
+        isHideFullClasses={isHideFullClasses}
       />
     ));
 
@@ -127,7 +132,8 @@ const Dropzones: React.FC<DropzonesProps> = React.memo(
       prev.selectedCourses.length !== next.selectedCourses.length ||
       prev.earliestStartTime !== next.earliestStartTime ||
       prev.selectedCourses.some((course, i) => course.code !== next.selectedCourses[i].code) ||
-      JSON.stringify(prev.assignedColors) !== JSON.stringify(next.assignedColors)
+      JSON.stringify(prev.assignedColors) !== JSON.stringify(next.assignedColors) ||
+      prev.isHideFullClasses !== next.isHideFullClasses
     )
 );
 

--- a/client/src/components/timetable/Timetable.tsx
+++ b/client/src/components/timetable/Timetable.tsx
@@ -42,6 +42,7 @@ interface TimetableProps {
   isSquareEdges: boolean;
   setInfoVisibility(value: boolean): void;
   isHideFullClasses: boolean;
+  isHideClassInfo: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
@@ -56,6 +57,7 @@ const Timetable: React.FC<TimetableProps> = React.memo(
     clashes,
     setInfoVisibility,
     isHideFullClasses,
+    isHideClassInfo,
   }) => (
     <StyledTimetableScroll id="StyledTimetableScroll">
       <StyledTimetable
@@ -84,6 +86,7 @@ const Timetable: React.FC<TimetableProps> = React.memo(
           clashes={clashes}
           isSquareEdges={isSquareEdges}
           setInfoVisibility={setInfoVisibility}
+          isHideClassInfo={isHideClassInfo}
         />
       </StyledTimetable>
     </StyledTimetableScroll>
@@ -96,7 +99,8 @@ const Timetable: React.FC<TimetableProps> = React.memo(
       prev.selectedCourses.some((course, i) => course.code !== next.selectedCourses[i].code) ||
       JSON.stringify(prev.assignedColors) !== JSON.stringify(next.assignedColors) ||
       prev.isSquareEdges !== next.isSquareEdges ||
-      prev.isHideFullClasses !== next.isHideFullClasses
+      prev.isHideFullClasses !== next.isHideFullClasses ||
+      prev.isHideClassInfo !== next.isHideClassInfo
     )
 );
 

--- a/client/src/components/timetable/Timetable.tsx
+++ b/client/src/components/timetable/Timetable.tsx
@@ -41,6 +41,7 @@ interface TimetableProps {
   clashes: Array<ClassPeriod>;
   isSquareEdges: boolean;
   setInfoVisibility(value: boolean): void;
+  isHideFullClasses: boolean;
 }
 
 // beware memo - if a component isn't re-rendering, it could be why
@@ -54,6 +55,7 @@ const Timetable: React.FC<TimetableProps> = React.memo(
     isSquareEdges,
     clashes,
     setInfoVisibility,
+    isHideFullClasses,
   }) => (
     <StyledTimetableScroll id="StyledTimetableScroll">
       <StyledTimetable
@@ -72,6 +74,7 @@ const Timetable: React.FC<TimetableProps> = React.memo(
           selectedCourses={selectedCourses}
           assignedColors={assignedColors}
           earliestStartTime={Math.min(...selectedCourses.map((course) => course.earliestStartTime), defaultStartTime)}
+          isHideFullClasses={isHideFullClasses}
         />
         <DroppedClasses
           selectedCourses={selectedCourses}
@@ -92,7 +95,8 @@ const Timetable: React.FC<TimetableProps> = React.memo(
       prev.selectedCourses.length !== next.selectedCourses.length ||
       prev.selectedCourses.some((course, i) => course.code !== next.selectedCourses[i].code) ||
       JSON.stringify(prev.assignedColors) !== JSON.stringify(next.assignedColors) ||
-      prev.isSquareEdges !== next.isSquareEdges
+      prev.isSquareEdges !== next.isSquareEdges ||
+      prev.isHideFullClasses !== next.isHideFullClasses
     )
 );
 

--- a/client/src/components/timetable/TimetableLayout.tsx
+++ b/client/src/components/timetable/TimetableLayout.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { Box } from '@material-ui/core';
 import { CourseData } from '../../interfaces/Course';
 import { defaultStartTime, defaultEndTime } from '../../constants/timetable';
 
@@ -70,18 +69,6 @@ const ToggleCell = styled(BaseCell)`
   & span {
     grid-column: 1;
     grid-row: 1;
-  }
-`;
-
-const Is12HourModeToggle = styled(Box)`
-  font-weight: bold;
-  cursor: pointer;
-  user-select: none;
-  transition: color 0.1s;
-  color: ${({ theme }) => theme.palette.primary.main};
-
-  &:hover {
-    color: ${({ theme }) => theme.palette.primary.dark};
   }
 `;
 
@@ -158,9 +145,6 @@ export const TimetableLayout: React.FC<TimetableLayoutProps> = React.memo(
     return (
       <>
         <ToggleCell key={0} x={1} y={1}>
-          <Is12HourModeToggle component="span" onClick={() => setIs12HourMode(!is12HourMode)}>
-            {`${is12HourMode ? '12' : '24'} h`}
-          </Is12HourModeToggle>
           {
             // Invisible guide for the column width for
             // consistency between 24 and 12 hour time.

--- a/client/src/constants/defaults.ts
+++ b/client/src/constants/defaults.ts
@@ -2,6 +2,8 @@ const defaults: Record<string, any> = {
   is12HourMode: false,
   isDarkMode: false,
   isSquareEdges: false,
+  isHideFullClasses: false,
+  isDefaultUnscheduled: false,
   userID: '',
   accessToken: '',
   userPicture: '',

--- a/client/src/constants/defaults.ts
+++ b/client/src/constants/defaults.ts
@@ -4,6 +4,7 @@ const defaults: Record<string, any> = {
   isSquareEdges: false,
   isHideFullClasses: false,
   isDefaultUnscheduled: false,
+  isHideClassInfo: false,
   userID: '',
   accessToken: '',
   userPicture: '',


### PR DESCRIPTION
- Moved existing settings for dark mode and 12h time format to the settings modal
- Added setting to hide classes at full capacity
- Added setting to move newly added classes to the Unscheduled column by default
- Minor changes to styling of settings modal
- Added "compact mode" setting which hides class information