### PR TITLE
raise 502 error if python raises error

### DIFF
--- a/server/src/controllers/getAutotimetable.ts
+++ b/server/src/controllers/getAutotimetable.ts
@@ -22,6 +22,8 @@ export const getAuto = async (req: Request, res: Response) => {
   client.findBestTimetable(constraints, (err, response) => {
     if (err) {
       console.log('error was found: ' + err);
+      res.status(502).send('An error occurred when handling the request.')
+
     } else {
       res.send(JSON.stringify({ given: response.getTimesList() }));
     }


### PR DESCRIPTION
It may be good to display more specific errors on the front end but the logic of the nested try catch blocks are difficult to follow so it will just display the default error message