### PR TITLE
Applied the fix that MJ recommended + no merge conflicts

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -211,14 +211,12 @@ const App: React.FC = () => {
     const fetchTermData = async () => {
       try {
         const termData = await getAvailableTermDetails();
-        if (termData !== undefined) {
-          let { term, termName, termNumber, year, firstDayOfTerm } = termData;
-          setTerm(term);
-          setTermName(termName);
-          setTermNumber(termNumber);
-          setYear(year);
-          setFirstDayOfTerm(firstDayOfTerm);
-        }
+        let { term, termName, termNumber, year, firstDayOfTerm } = termData;
+        setTerm(term);
+        setTermName(termName);
+        setTermNumber(termNumber);
+        setYear(year);
+        setFirstDayOfTerm(firstDayOfTerm);
       } catch (e) {
         if (e instanceof NetworkError) {
           setAlertMsg(e.message);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -211,12 +211,14 @@ const App: React.FC = () => {
     const fetchTermData = async () => {
       try {
         const termData = await getAvailableTermDetails();
-        const { term, termName, termNumber, firstDayOfTerm, year } = termData;
-        setTerm(term);
-        setTermName(termName);
-        setTermNumber(termNumber);
-        setYear(year);
-        setFirstDayOfTerm(firstDayOfTerm);
+        if (termData !== undefined) {
+          let { term, termName, termNumber, year, firstDayOfTerm } = termData;
+          setTerm(term);
+          setTermName(termName);
+          setTermNumber(termNumber);
+          setYear(year);
+          setFirstDayOfTerm(firstDayOfTerm);
+        }
       } catch (e) {
         if (e instanceof NetworkError) {
           setAlertMsg(e.message);

--- a/client/src/constants/timetable.ts
+++ b/client/src/constants/timetable.ts
@@ -7,14 +7,26 @@ import timeoutPromise from '../utils/timeoutPromise';
 /**
  * @returns The details of the latest term there is data for
  */
+
 export const getAvailableTermDetails = async () => {
   // These are invalid term strings that are initially set
-  // The API will replace them with valid ones and return the updated values.
-  let year = '0000';
-  let termNumber = 1;
-  let term = `T${termNumber}`;
+  // and the api will replace them with valid ones and return them.
+  let termData = {
+    year: '',
+    term: '',
+    termNumber: '',
+    termName: '',
+    firstDayOfTerm: '',
+  };
+
+  if (localStorage.getItem('termData')) {
+    termData = JSON.parse(localStorage.getItem('termData')!);
+  }
+  let year = termData.year || '0000';
+  let termNumber = Number(termData.termNumber) || 1;
+  let term = termData.termName || `T${termNumber}`;
   let termName = `Term ${termNumber}`;
-  let firstDayOfTerm = `0000-00-00`;
+  let firstDayOfTerm = termData.firstDayOfTerm || `0000-00-00`;
 
   try {
     const termDateFetch = await timeoutPromise(1000, fetch(`${API_URL.timetable}/startdate/notangles`));
@@ -43,6 +55,17 @@ export const getAvailableTermDetails = async () => {
       term = termIdRes;
       termNumber = 0; // This is a summer term.
     }
+    // Store the term details in local storage.
+    localStorage.setItem(
+      'termData',
+      JSON.stringify({
+        year: year,
+        term: term,
+        termNumber: termNumber,
+        termName: termName,
+        firstDayOfTerm: firstDayOfTerm,
+      })
+    );
 
     return {
       term: term,
@@ -52,7 +75,7 @@ export const getAvailableTermDetails = async () => {
       firstDayOfTerm: firstDayOfTerm,
     };
   } catch (e) {
-    throw new NetworkError('Could not conect to timetable scraper!');
+    console.log('Could not ping timetable scraper!');
   }
 };
 

--- a/client/src/constants/timetable.ts
+++ b/client/src/constants/timetable.ts
@@ -1,13 +1,12 @@
-const REGULAR_TERM_STR_LEN = 2;
-
 import { API_URL } from '../api/config';
 import NetworkError from '../interfaces/NetworkError';
 import timeoutPromise from '../utils/timeoutPromise';
 
+const REGULAR_TERM_STR_LEN = 2;
+
 /**
  * @returns The details of the latest term there is data for
  */
-
 export const getAvailableTermDetails = async () => {
   // These are invalid term strings that are initially set
   // and the api will replace them with valid ones and return them.
@@ -75,7 +74,7 @@ export const getAvailableTermDetails = async () => {
       firstDayOfTerm: firstDayOfTerm,
     };
   } catch (e) {
-    console.log('Could not ping timetable scraper!');
+    throw new NetworkError('Could not conect to timetable scraper!');
   }
 };
 

--- a/client/src/constants/timetable.ts
+++ b/client/src/constants/timetable.ts
@@ -75,7 +75,7 @@ export const getAvailableTermDetails = async () => {
       firstDayOfTerm: firstDayOfTerm,
     };
   } catch (e) {
-    console.log('Could not ping timetable scraper!');
+    throw new NetworkError('Could not conect to timetable scraper!');
   }
 };
 

--- a/client/src/context/AppContext.tsx
+++ b/client/src/context/AppContext.tsx
@@ -134,6 +134,16 @@ export const AppContext = createContext<IAppContext>({
 });
 
 const AppContextProvider = ({ children }: AppContextProviderProps) => {
+  let termData = {
+    year: '',
+    term: '',
+    termNumber: '',
+    termName: '',
+    firstDayOfTerm: '',
+  };
+  if (localStorage.getItem('termData')) {
+    termData = JSON.parse(localStorage.getItem('termData')!);
+  }
   const [is12HourMode, setIs12HourMode] = useState<boolean>(storage.get('is12HourMode'));
   const [isDarkMode, setIsDarkMode] = useState<boolean>(storage.get('isDarkMode'));
   const [isSquareEdges, setIsSquareEdges] = useState<boolean>(storage.get('isSquareEdges'));
@@ -148,14 +158,13 @@ const AppContextProvider = ({ children }: AppContextProviderProps) => {
   const [lastUpdated, setLastUpdated] = useState<number>(0);
   const [isDrag, setIsDrag] = useState<boolean>(false);
   const [days, setDays] = useState<string[]>(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']);
-  const [termNumber, setTermNumber] = useState<number>(0);
-  const [term, setTerm] = useState<string>(`T0`);
-  const [termName, setTermName] = useState<string>(`Term 0`);
-  const [year, setYear] = useState<string>('0000');
-  const [firstDayOfTerm, setFirstDayOfTerm] = useState<string>('0000-00-00');
   const [earliestStartTime, setEarliestStartTime] = useState(9);
   const [latestEndTime, setLatestEndTime] = useState(18);
-
+  const [termNumber, setTermNumber] = useState<number>(Number(termData.termNumber) || 0);
+  const [term, setTerm] = useState<string>(termData.term || `T0`);
+  const [termName, setTermName] = useState<string>(`Term ${termNumber}`);
+  const [year, setYear] = useState<string>(termData.year || '0000');
+  const [firstDayOfTerm, setFirstDayOfTerm] = useState<string>(termData.firstDayOfTerm || `0000-00-00`);
   const initialContext: IAppContext = {
     is12HourMode,
     setIs12HourMode,


### PR DESCRIPTION
This is basically using localStorage to check if data exists 
If it does, it uses that data AND pings API for new term data after and updates localStorage.
If not, it uses 0000 temporarily (This only happens if localStorage is cleared or the first time logging in the browser), and then we get data from API and set localStorage.
 