### PR TITLE
fix cards moving to the side on drag start

### DIFF
--- a/client/src/utils/Drag.ts
+++ b/client/src/utils/Drag.ts
@@ -631,6 +631,7 @@ export const setDragTarget = (
 
       lastRecWidth = element.getBoundingClientRect().width;
 
+      prevWidth = -1;
       resizeObserver.observe(dragElement);
 
       if (cardData.type !== 'event') {


### PR DESCRIPTION
bug setup: click and release a card of width W1 and then click a card of width W2, where W1 != W2