### PR TITLE
include user created events in auto timetabling

### DIFF
--- a/client/src/components/controls/Autotimetabler.tsx
+++ b/client/src/components/controls/Autotimetabler.tsx
@@ -187,7 +187,7 @@ const Autotimetabler: React.FC<AutotimetableProps> = ({ handleSelectClass }) => 
       .map((k, index) => [k, autoParams[index]])
       .reduce((o, key) => ({ ...o, [key[0]]: key[1] }), {});
 
-    // we treat events as single-period classes with a sole time slot
+    // We treat events as single-period classes with a sole time slot
     timetableData['periodInfoList'] = [
       ...periodInfoPerMode.current[`${classMode}`],
       ...Object.values(createdEvents).map(
@@ -201,8 +201,8 @@ const Autotimetabler: React.FC<AutotimetableProps> = ({ handleSelectClass }) => 
     ];
 
     try {
-      const [resultsIncEvents, isOptimal] = await getAutoTimetable(timetableData);
-      const results = resultsIncEvents.slice(0, targetActivities.current.length);
+      const [resultsWithEvents, isOptimal] = await getAutoTimetable(timetableData);
+      const results = resultsWithEvents.slice(0, targetActivities.current.length);
 
       setAutoVisibility(true);
       setAlertMsg(results.length ? (isOptimal ? 'Success!' : 'Could not satisfy perfectly') : 'No timetable found');

--- a/client/src/components/controls/Autotimetabler.tsx
+++ b/client/src/components/controls/Autotimetabler.tsx
@@ -81,7 +81,7 @@ const Autotimetabler: React.FC<AutotimetableProps> = ({ handleSelectClass }) => 
   const popoverId = open ? 'simple-popover' : undefined;
 
   const { setAutoVisibility, setAlertMsg, setErrorVisibility } = useContext(AppContext);
-  const { selectedCourses } = useContext(CourseContext);
+  const { selectedCourses, createdEvents } = useContext(CourseContext);
 
   const targetActivities = useRef<ClassData[][]>([]);
   const periodInfoPerMode = useRef<Record<ClassMode, PeriodInfo[]>>({ hybrid: [], 'in person': [], online: [] });
@@ -187,10 +187,22 @@ const Autotimetabler: React.FC<AutotimetableProps> = ({ handleSelectClass }) => 
       .map((k, index) => [k, autoParams[index]])
       .reduce((o, key) => ({ ...o, [key[0]]: key[1] }), {});
 
-    timetableData['periodInfoList'] = periodInfoPerMode.current[`${classMode}`];
+    // we treat events as single-period classes with a sole time slot
+    timetableData['periodInfoList'] = [
+      ...periodInfoPerMode.current[`${classMode}`],
+      ...Object.values(createdEvents).map(
+        (eventPeriod) =>
+          ({
+            periodsPerClass: 1,
+            periodTimes: [eventPeriod.time.day, eventPeriod.time.start],
+            durations: [eventPeriod.time.end - eventPeriod.time.start],
+          } as PeriodInfo)
+      ),
+    ];
 
     try {
-      const [results, isOptimal] = await getAutoTimetable(timetableData);
+      const [resultsIncEvents, isOptimal] = await getAutoTimetable(timetableData);
+      const results = resultsIncEvents.slice(0, targetActivities.current.length);
 
       setAutoVisibility(true);
       setAlertMsg(results.length ? (isOptimal ? 'Success!' : 'Could not satisfy perfectly') : 'No timetable found');

--- a/client/src/components/navbar/Changelog.tsx
+++ b/client/src/components/navbar/Changelog.tsx
@@ -15,6 +15,10 @@ type Change = { date: String; changes: String[] };
 
 const changelog: Change[] = [
   {
+    date: 'September 11, 2022',
+    changes: ['Autotimetabling now schedules around your custom events'],
+  },
+  {
     date: 'September 6, 2022',
     changes: ['Added ability to clone a created custom event'],
   },


### PR DESCRIPTION
Makes auto timetabling be aware of created events and make it try to assign classes so that it does not interfere with any of these times. It does not itself make changes to the times of user events.