### PR TITLE
NTGL-370: Clashes Bug

### DIFF
--- a/client/src/utils/clashes.ts
+++ b/client/src/utils/clashes.ts
@@ -190,7 +190,7 @@ export const getClashInfo = (groupedClashes: Record<number, (ClassPeriod | Event
 
     if (!clashGroup) return defaultValues;
 
-    const uniqueClashIDs = [...Array.from(new Set(clashGroup.map((clash) => getId(clash))))];
+    const uniqueClashIDs = Array.from(new Set(clashGroup.map((clash) => getId(clash))));
 
     const nonLecturePeriods = clashGroup
       .filter((clash) => clash.type === 'class' && !clash.activity.includes('Lecture'))

--- a/client/src/utils/clashes.ts
+++ b/client/src/utils/clashes.ts
@@ -161,6 +161,8 @@ export const findClashes = (selectedClasses: SelectedClasses, createdEvents: Cre
   const sortedClashes = sortClashesByDay(clashes);
   const groupedClashes = groupClashes(sortedClashes);
 
+  console.log(groupedClashes);
+
   return groupedClashes;
 };
 
@@ -190,7 +192,9 @@ export const getClashInfo = (groupedClashes: Record<number, (ClassPeriod | Event
 
     if (!clashGroup) return defaultValues;
 
-    const uniqueClashIDs = clashGroup.map((clash) => getId(clash));
+    // Get the unique class IDs of the classes in the clash group.
+    const uniqueClashIDs = [...Array.from(new Set(clashGroup.map((clash) => getId(clash))))];
+
     const nonLecturePeriods = clashGroup
       .filter((clash) => clash.type === 'class' && !clash.activity.includes('Lecture'))
       .map((clash) => getId(clash));

--- a/client/src/utils/clashes.ts
+++ b/client/src/utils/clashes.ts
@@ -161,8 +161,6 @@ export const findClashes = (selectedClasses: SelectedClasses, createdEvents: Cre
   const sortedClashes = sortClashesByDay(clashes);
   const groupedClashes = groupClashes(sortedClashes);
 
-  console.log(groupedClashes);
-
   return groupedClashes;
 };
 

--- a/client/src/utils/clashes.ts
+++ b/client/src/utils/clashes.ts
@@ -190,7 +190,6 @@ export const getClashInfo = (groupedClashes: Record<number, (ClassPeriod | Event
 
     if (!clashGroup) return defaultValues;
 
-    // Get the unique class IDs of the classes in the clash group.
     const uniqueClashIDs = [...Array.from(new Set(clashGroup.map((clash) => getId(clash))))];
 
     const nonLecturePeriods = clashGroup


### PR DESCRIPTION
clashing classes weren't displaying properly because when getting the number of unique clash ids in a certain clash group, it counted the tut and lab as two separate classes. not pawg