### PR TITLE
fix mobile drag bug causing screen shift on next drag

### DIFF
--- a/client/src/utils/Drag.ts
+++ b/client/src/utils/Drag.ts
@@ -618,6 +618,13 @@ export const setDragTarget = (
         lastY = event.pageY;
       } else if (typeof event.touches === 'object' && typeof event.touches[0] === 'object') {
         const touch = event.touches[0];
+
+        // reupdates clientX/Y so onFrame() won't think finger's still at edge of screen
+        // and try scroll screen (not prob on computer as mousemove will 100% fire before next
+        // card drag and update it for us but *touchmove* won't)
+        clientX = touch.clientX;
+        clientY = touch.clientY;
+
         if (typeof touch.pageX === 'number' && typeof touch.pageY === 'number') {
           lastX = touch.pageX;
           lastY = touch.pageY;


### PR DESCRIPTION
bug set up:

drag a card to the edge of the screen (with your finger) so that the window starts to scroll. then, whilst the window is scrolling, lift finger so that the card returns to it's original position. Then go back to the card and touch-hold it to start another drag, the screen will immediately scroll for a while with the card moving alongside the screen.