### PR TITLE
make event drop calculation more accurate

### DIFF
--- a/client/src/utils/Drag.ts
+++ b/client/src/utils/Drag.ts
@@ -793,14 +793,14 @@ const drop = () => {
         const baserect = gridChildren[1].getBoundingClientRect();
 
         // x and y displacement of the drag target from the start-point of the grid
-        const displacementx = dragrect.x - baserect.x;
+        const displacementx = dragrect.x + dragrect.width / 2 - baserect.x;
         const displacementy = dragrect.y - (baserect.y + baserect.height + 1);
 
         // Get the size of an arbitrary grid cell
         const itemRect = gridChildren[Math.floor(gridChildren.length / 2)].getBoundingClientRect();
 
         // Get the grid coordinates of the dragTarget when released
-        const [colIndex, rowIndex] = [Math.round(displacementx / itemRect.width), Math.round(displacementy / itemRect.height)];
+        const [colIndex, rowIndex] = [Math.floor(displacementx / itemRect.width), Math.round(displacementy / itemRect.height)];
 
         const eventLength = dragTarget.time.end - dragTarget.time.start;
 


### PR DESCRIPTION
replaces this behavior:

![one](https://user-images.githubusercontent.com/22385238/198420391-1cf61fdf-fc27-4487-b07b-910f2d6f94b5.gif)

with this:

![two](https://user-images.githubusercontent.com/22385238/198420587-1870a618-7c7f-4e71-87c7-b9fb698dbda0.gif)
