### PR TITLE
Feature/ntgl 396 shift timetable times

### DIFF
--- a/client/src/components/timetable/TimetableLayout.tsx
+++ b/client/src/components/timetable/TimetableLayout.tsx
@@ -44,8 +44,8 @@ const BaseCell = styled('div', {
   outline: solid ${({ theme }) => theme.palette.secondary.main} 1px;
   outline-offset: -0.5px;
 
-  border-top-left-radius: ${({ theme, x, y }) => (x === 1 && y === 1 ? theme.shape.borderRadius : 0)}px;
-  border-bottom-left-radius: ${({ theme, x, isEndY }) => (x === 1 && isEndY ? theme.shape.borderRadius : 0)}px;
+  border-top-left-radius: ${({ theme, x, y }) => (x === 2 && y === 1 ? theme.shape.borderRadius : 0)}px;
+  border-bottom-left-radius: ${({ theme, x, isEndY }) => (x === 2 && isEndY ? theme.shape.borderRadius : 0)}px;
   border-top-right-radius: ${({ theme, isEndX, y }) => (isEndX && y === 1 ? theme.shape.borderRadius : 0)}px;
   border-bottom-right-radius: ${({ theme, isEndX, isEndY }) => (isEndX && isEndY ? theme.shape.borderRadius : 0)}px;
 `;
@@ -174,7 +174,7 @@ export const TimetableLayout: React.FC<TimetableLayoutProps> = ({ copiedEvent, s
 
   const hours: string[] = generateHours(hoursRange, is12HourMode, setAlertMsg, setErrorVisibility, isConvertToLocalTimezone);
   const hourCells = hours.map((hour, i) => (
-    <HourCell key={hour} x={1} y={i + 2} is12HourMode={is12HourMode} isEndY={i === hours.length - 1}>
+    <HourCell key={hour} x={1} y={i + 2} is12HourMode={is12HourMode}>
       {hour}
     </HourCell>
   ));

--- a/client/src/components/timetable/TimetableLayout.tsx
+++ b/client/src/components/timetable/TimetableLayout.tsx
@@ -76,21 +76,22 @@ const HourCell = styled(GridCell, {
   outline: none;
 `;
 
-// const ToggleCell = styled(BaseCell)`
-//   padding: 0 ${headerPadding}px;
-//   display: grid;
-//   justify-content: center;
+const ToggleCell = styled(BaseCell)`
+  padding: 0 ${headerPadding}px;
+  display: grid;
+  justify-content: center;
+  outline: none;
 
-//   & span {
-//     grid-column: 1;
-//     grid-row: 1;
-//   }
-// `;
+  & span {
+    grid-column: 1;
+    grid-row: 1;
+  }
+`;
 
-// const ColumnWidthGuide = styled('span')`
-//   opacity: 0;
-//   pointer-events: none;
-// `;
+const ColumnWidthGuide = styled('span')`
+  opacity: 0;
+  pointer-events: none;
+`;
 
 /**
  * @param n The numerical value of the hour
@@ -262,14 +263,14 @@ export const TimetableLayout: React.FC<TimetableLayoutProps> = ({ copiedEvent, s
 
   return (
     <>
-      {/* <ToggleCell key={0} x={1} y={1}>
+      <ToggleCell key={0} x={1} y={1}>
         {
           // Invisible guide for the column width for
           // consistency between 24 and 12 hour time.
           // Content is something like '10 AM'.
         }
         <ColumnWidthGuide>{generateHour(10, true)}</ColumnWidthGuide>
-      </ToggleCell> */}
+      </ToggleCell>
       {dayCells}
       {hourCells}
       {otherCells}

--- a/client/src/components/timetable/TimetableLayout.tsx
+++ b/client/src/components/timetable/TimetableLayout.tsx
@@ -73,7 +73,7 @@ const HourCell = styled(GridCell, {
   padding: 0 ${headerPadding}px;
   display: grid;
   justify-content: ${({ is12HourMode }) => (is12HourMode ? 'end' : 'center')};
-  margin-top: -${rowHeight / 2}px;
+  margin-top: -${rowHeight / 2 + 1}px;
   outline: none;
 `;
 

--- a/client/src/components/timetable/TimetableLayout.tsx
+++ b/client/src/components/timetable/TimetableLayout.tsx
@@ -56,7 +56,7 @@ const GridCell = styled(BaseCell)`
 
 const DayCell = styled(BaseCell)`
   padding: ${headerPadding}px 0;
-  border-bottom: 3px solid ${({ theme }) => theme.palette.secondary.main};
+  border-bottom: 2px solid ${({ theme }) => theme.palette.secondary.main};
 `;
 
 const InventoryCell = styled(DayCell)`
@@ -64,7 +64,6 @@ const InventoryCell = styled(DayCell)`
   border-top-right-radius: ${({ theme, y }) => (y === 1 ? theme.shape.borderRadius : 0)}px;
   border-bottom-left-radius: ${({ theme, y }) => (y !== 1 ? theme.shape.borderRadius : 0)}px;
   border-bottom-right-radius: ${({ theme, y }) => (y !== 1 ? theme.shape.borderRadius : 0)}px;
-  border-bottom: 0px;
 `;
 
 const HourCell = styled(GridCell, {

--- a/client/src/components/timetable/TimetableLayout.tsx
+++ b/client/src/components/timetable/TimetableLayout.tsx
@@ -56,6 +56,7 @@ const GridCell = styled(BaseCell)`
 
 const DayCell = styled(BaseCell)`
   padding: ${headerPadding}px 0;
+  border-bottom: 3px solid ${({ theme }) => theme.palette.secondary.main};
 `;
 
 const InventoryCell = styled(DayCell)`
@@ -63,6 +64,7 @@ const InventoryCell = styled(DayCell)`
   border-top-right-radius: ${({ theme, y }) => (y === 1 ? theme.shape.borderRadius : 0)}px;
   border-bottom-left-radius: ${({ theme, y }) => (y !== 1 ? theme.shape.borderRadius : 0)}px;
   border-bottom-right-radius: ${({ theme, y }) => (y !== 1 ? theme.shape.borderRadius : 0)}px;
+  border-bottom: 0px;
 `;
 
 const HourCell = styled(GridCell, {
@@ -71,8 +73,7 @@ const HourCell = styled(GridCell, {
   padding: 0 ${headerPadding}px;
   display: grid;
   justify-content: ${({ is12HourMode }) => (is12HourMode ? 'end' : 'center')};
-  align-items: flex-start;
-  margin-top: -11px;
+  margin-top: -${rowHeight / 2}px;
   outline: none;
 `;
 

--- a/client/src/components/timetable/TimetableLayout.tsx
+++ b/client/src/components/timetable/TimetableLayout.tsx
@@ -71,23 +71,26 @@ const HourCell = styled(GridCell, {
   padding: 0 ${headerPadding}px;
   display: grid;
   justify-content: ${({ is12HourMode }) => (is12HourMode ? 'end' : 'center')};
+  align-items: flex-start;
+  margin-top: -11px;
+  outline: none;
 `;
 
-const ToggleCell = styled(BaseCell)`
-  padding: 0 ${headerPadding}px;
-  display: grid;
-  justify-content: center;
+// const ToggleCell = styled(BaseCell)`
+//   padding: 0 ${headerPadding}px;
+//   display: grid;
+//   justify-content: center;
 
-  & span {
-    grid-column: 1;
-    grid-row: 1;
-  }
-`;
+//   & span {
+//     grid-column: 1;
+//     grid-row: 1;
+//   }
+// `;
 
-const ColumnWidthGuide = styled('span')`
-  opacity: 0;
-  pointer-events: none;
-`;
+// const ColumnWidthGuide = styled('span')`
+//   opacity: 0;
+//   pointer-events: none;
+// `;
 
 /**
  * @param n The numerical value of the hour
@@ -259,14 +262,14 @@ export const TimetableLayout: React.FC<TimetableLayoutProps> = ({ copiedEvent, s
 
   return (
     <>
-      <ToggleCell key={0} x={1} y={1}>
+      {/* <ToggleCell key={0} x={1} y={1}>
         {
           // Invisible guide for the column width for
           // consistency between 24 and 12 hour time.
           // Content is something like '10 AM'.
         }
         <ColumnWidthGuide>{generateHour(10, true)}</ColumnWidthGuide>
-      </ToggleCell>
+      </ToggleCell> */}
       {dayCells}
       {hourCells}
       {otherCells}


### PR DESCRIPTION
- Re-styled the hour cells to have no outlines and for their times to be more aligned with the timetable.
- Styled the line below the day cells to be thicker.