### PR TITLE
removed text that is misleading for shortcuts for deleting timetable …

### DIFF
--- a/client/src/components/timetableTabs/TimetableTabContextMenu.tsx
+++ b/client/src/components/timetableTabs/TimetableTabContextMenu.tsx
@@ -50,7 +50,7 @@ const TimetableTabContextMenu: React.FC<TimetableTabContextMenuProps> = ({ ancho
 
   const isMacOS = navigator.userAgent.indexOf('Mac') != -1;
 
-  const deleteTimetabletip = isMacOS ? 'Delete Tab (Cmd+Shift+x)' : 'Delete Tab (Ctrl+Shift+x)';
+  const deleteTimetabletip = 'Delete Tab';
 
   const [renameOpen, setRenameOpen] = useState<boolean>(false);
   const [renamedString, setRenamedString] = useState<string>('');


### PR DESCRIPTION
Biggest PR in Notangles history.
removing the delete timetable tooltip for the shortcuts that were removed in a previous PR.