### PR TITLE
Enforce Sydney timezone by default

### DIFF
--- a/client/src/context/AppContext.tsx
+++ b/client/src/context/AppContext.tsx
@@ -114,7 +114,7 @@ export const AppContext = createContext<IAppContext>({
   isHideExamClasses: false,
   setIsHideExamClasses: () => {},
 
-  isConvertToLocalTimezone: true,
+  isConvertToLocalTimezone: false,
   setIsConvertToLocalTimezone: () => {},
 
   alertMsg: '',


### PR DESCRIPTION
For a UNSW term planner, it is not intuitive to show class times in local timezone rather to the timezone of the university. This particularly burns students planning their timetable (in a rush) whilst overseas/interstate the week before term starts. This PR changes the default option to Sydney/UNSW timezone, allowing users to opt-in instead to see their local timezone. This could be made into a popup/notification later for those detected to be in another timezone.