### PR TITLE
Set new classes going to unscheduled as default

### DIFF
--- a/client/src/constants/defaults.ts
+++ b/client/src/constants/defaults.ts
@@ -5,7 +5,7 @@ const defaults: Record<string, any> = {
   isDarkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
   isSquareEdges: false,
   isShowOnlyOpenClasses: false,
-  isDefaultUnscheduled: false,
+  isDefaultUnscheduled: true,
   isHideClassInfo: false,
   isHideExamClasses: false,
   isConvertToLocalTimezone: false,

--- a/client/src/context/AppContext.tsx
+++ b/client/src/context/AppContext.tsx
@@ -105,7 +105,7 @@ export const AppContext = createContext<IAppContext>({
   isShowOnlyOpenClasses: false,
   setisShowOnlyOpenClasses: () => {},
 
-  isDefaultUnscheduled: false,
+  isDefaultUnscheduled: true,
   setIsDefaultUnscheduled: () => {},
 
   isHideClassInfo: false,


### PR DESCRIPTION
Why? The automatically selected times are not usually people's final choice, and it's nicer to users to just drag in the times manually, particularly if they're scheduling entire courses at a time.