### PR TITLE
Update Prisma schema to populate course id field

### DIFF
--- a/server/prisma/migrations/20250424101523_fill_course_id/migration.sql
+++ b/server/prisma/migrations/20250424101523_fill_course_id/migration.sql
@@ -1,0 +1,4 @@
+-- classNo is currently a string such as COMP6420Undergraduate-11965-T1-2025
+-- courseId should be a string such as COMP6420Undergraduate
+UPDATE "classes"
+SET "courseId" = split_part("classNo", '-', 1);

--- a/server/prisma/migrations/20250424102004_require_course_id/migration.sql
+++ b/server/prisma/migrations/20250424102004_require_course_id/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `courseId` on table `classes` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "classes" ALTER COLUMN "courseId" SET NOT NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -71,7 +71,7 @@ model Class {
   term        String
   year        String
   courseCode  String
-  courseId    String?
+  courseId    String
   Timetable   Timetable? @relation(fields: [timetableId], references: [id], onDelete: Cascade)
   timetableId String?
   activity    String


### PR DESCRIPTION
- First update populates the course id field for classes in the user database
- Second update makes the field mandatory

Once this is merged in, we are safe to start updating the backend and frontend accordingly