### PR TITLE
Fix authorisation for all backend routes

### DIFF
--- a/client/src/api/getAutoTimetable.ts
+++ b/client/src/api/getAutoTimetable.ts
@@ -10,6 +10,7 @@ const getAutoTimetable = async (data: any): Promise<[number[], boolean]> => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(data),
+      credentials: 'include',
     });
 
     if (res.status !== 201) {

--- a/client/src/components/sidebar/groupsSidebar/AddOrEditGroupDialogContent.tsx
+++ b/client/src/components/sidebar/groupsSidebar/AddOrEditGroupDialogContent.tsx
@@ -112,6 +112,7 @@ const AddOrEditGroupDialogContent: React.FC<AddGroupDialogContentProps> = ({
           groupAdminIDs: group.groupAdmins.map((groupAdmin) => groupAdmin.userID),
           imageURL: group.imageURL,
         }),
+        credentials: 'include',
       });
       const groupCreationStatus = await res.json();
       console.log('group creation status', groupCreationStatus.data); // Can see the status of group creation here!
@@ -144,6 +145,7 @@ const AddOrEditGroupDialogContent: React.FC<AddGroupDialogContentProps> = ({
           groupAdminIDs: group.groupAdmins.map((groupAdmin) => groupAdmin.userID),
           imageURL: group.imageURL,
         }),
+        credentials: 'include',
       });
       const groupCreationStatus = await res.json();
       console.log('group update status', groupCreationStatus.data); // Can see the status of group creation here!

--- a/client/src/components/sidebar/groupsSidebar/GroupCircle.tsx
+++ b/client/src/components/sidebar/groupsSidebar/GroupCircle.tsx
@@ -61,6 +61,7 @@ const AdminMenu: React.FC<{
           Accept: 'application/json',
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
       });
       const groupDeleteStatus = await res.json();
       console.log('group delete status', groupDeleteStatus);
@@ -114,6 +115,7 @@ const MemberMenu: React.FC<{ userID: string; group: Group; fetchUserInfo: (userI
           groupAdminIDs: group.groupAdmins.map((groupAdmins) => groupAdmins.userID),
           imageURL: group.imageURL,
         }),
+        credentials: 'include',
       });
       const leaveGroupStatus = await res.json();
       console.log('leave group status', leaveGroupStatus.data);

--- a/client/src/components/sidebar/groupsSidebar/friends/AddAFriendTab.tsx
+++ b/client/src/components/sidebar/groupsSidebar/friends/AddAFriendTab.tsx
@@ -40,6 +40,7 @@ const AddAFriendTab: React.FC<{ user: User; fetchUserInfo: (userID: string) => v
           Accept: 'application/json',
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
       });
       if (res.status !== 200) throw new NetworkError("Couldn't get response");
       const getUsersStatus = await res.json();
@@ -83,6 +84,7 @@ const AddAFriendTab: React.FC<{ user: User; fetchUserInfo: (userID: string) => v
           senderId: user.userID,
           sendeeId: otherUserID,
         }),
+        credentials: 'include',
       });
       if (res.status !== 201) throw new NetworkError("Couldn't get response");
       const acceptRequestStatus = await res.json();
@@ -105,6 +107,7 @@ const AddAFriendTab: React.FC<{ user: User; fetchUserInfo: (userID: string) => v
           sendeeId: otherUserID,
           senderId: user.userID,
         }),
+        credentials: 'include',
       });
       if (res.status !== 200) throw new NetworkError("Couldn't get response");
       const declineRequestStatus = await res.json();

--- a/client/src/components/sidebar/groupsSidebar/friends/RequestsTab.tsx
+++ b/client/src/components/sidebar/groupsSidebar/friends/RequestsTab.tsx
@@ -37,6 +37,7 @@ const RequestsTab: React.FC<{ user: User; fetchUserInfo: (userID: string) => voi
           sendeeId: user.userID,
           senderId: incomingUserId,
         }),
+        credentials: 'include',
       });
       if (res.status !== 200) throw new NetworkError("Couldn't get response");
       const declineRequestStatus = await res.json();
@@ -59,6 +60,7 @@ const RequestsTab: React.FC<{ user: User; fetchUserInfo: (userID: string) => voi
           senderId: user.userID,
           sendeeId: incomingUserId,
         }),
+        credentials: 'include',
       });
       if (res.status !== 201) throw new NetworkError("Couldn't get response");
       const acceptRequestStatus = await res.json();

--- a/client/src/components/sidebar/groupsSidebar/friends/YourFriendsTab.tsx
+++ b/client/src/components/sidebar/groupsSidebar/friends/YourFriendsTab.tsx
@@ -32,6 +32,7 @@ const YourFriendsTab: React.FC<{ user: User; fetchUserInfo: (userID: string) => 
           senderId: user.userID,
           sendeeId: friendID,
         }),
+        credentials: 'include',
       });
       if (res.status !== 200) throw new NetworkError("Couldn't get response");
       const acceptRequestStatus = await res.json();

--- a/client/src/context/UserContext.tsx
+++ b/client/src/context/UserContext.tsx
@@ -66,6 +66,7 @@ const UserContextProvider = ({ children }: UserContextProviderProps) => {
           Accept: 'application/json',
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
       });
       const res = await response.json();
       const timetables = await Promise.all(
@@ -115,6 +116,7 @@ const UserContextProvider = ({ children }: UserContextProviderProps) => {
           Accept: 'application/json',
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
       });
       if (res.status !== 200) throw new NetworkError("Couldn't get response");
       const jsonData = await res.json();

--- a/client/src/utils/syncTimetables.ts
+++ b/client/src/utils/syncTimetables.ts
@@ -176,6 +176,7 @@ export const syncAddTimetable = async (userId: string, newTimetable: TimetableDa
         name,
         mapKey: term,
       }),
+      credentials: 'include',
     });
 
     const json = await res.json();
@@ -193,6 +194,7 @@ const syncDeleteTimetable = async (timetableId: string) => {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
+      credentials: 'include',
     });
   } catch (e) {
     console.log(e);
@@ -215,6 +217,7 @@ const syncEditTimetable = async (userId: string, editedTimetable: TimetableData)
         userId: userId,
         timetable: convertTimetableToDTO(editedTimetable),
       }),
+      credentials: 'include',
     });
   } catch (e) {
     console.log(e);

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,12 +5,15 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { AutoModule } from './auto/auto.module';
 import config from './config';
-import { FriendModule } from './friend/friend.module';
-import { GroupModule } from './group/group.module';
+// import { FriendModule } from './friend/friend.module';
+// import { GroupModule } from './group/group.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { UserModule } from './user/user.module';
 import { GraphqlService } from './graphql/graphql.service';
 import { GraphqlModule } from './graphql/graphql.module';
+
+// TOOD: Re-enable FriendModule and GroupModule when ready
+// Need to be locked down better, and FE supported
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -21,10 +24,10 @@ import { GraphqlModule } from './graphql/graphql.module';
     AuthModule,
     AutoModule,
     UserModule,
-    FriendModule,
+    // FriendModule,
     PrismaModule,
     GraphqlModule,
-    GroupModule,
+    // GroupModule,
   ],
   controllers: [AppController],
   providers: [AppService, GraphqlService],

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -83,6 +83,6 @@ export class AuthController {
 
   @Get('/logout')
   async logout(@Request() req, @Res() res: Response) {
-    this.authService.logout(req, res);
+    await this.authService.logout(req, res);
   }
 }

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -13,22 +13,34 @@ export class AuthService {
       `${process.env.OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER}/.well-known/openid-configuration`,
     );
 
+    const postLogoutRedirect = this.configService.get<string>(
+      'app.redirectLink',
+      process.env.OAUTH2_CLIENT_REGISTRATION_LOGIN_POST_LOGOUT_REDIRECT_URI,
+    );
+
     if (!id_token || !TrustIssuer) {
-      return res.redirect(this.configService.get<string>('app.redirectLink'));
+      return res.redirect(postLogoutRedirect);
     }
 
-    req.logout((err) => {
-      req.session.destroy(async (error: any) => {
-        const end_session_endpoint = TrustIssuer.metadata.end_session_endpoint;
-        if (end_session_endpoint) {
-          res.redirect(
-            end_session_endpoint +
-              '?post_logout_redirect_uri=' +
-              process.env
-                .OAUTH2_CLIENT_REGISTRATION_LOGIN_POST_LOGOUT_REDIRECT_URI +
-              (id_token ? '&id_token_hint=' + id_token : ''),
-          );
-        }
+    const endSessionEndpoint = TrustIssuer.metadata.end_session_endpoint;
+
+    return new Promise((resolve, reject) => {
+      req.logout((err) => {
+        if (err) return reject(err);
+
+        req.session.destroy((error) => {
+          if (error) return reject(error);
+
+          if (endSessionEndpoint && id_token) {
+            res.redirect(
+              `${endSessionEndpoint}?post_logout_redirect_uri=${postLogoutRedirect}&id_token_hint=${id_token}`,
+            );
+          } else {
+            res.redirect(postLogoutRedirect);
+          }
+
+          resolve();
+        });
       });
     });
   }

--- a/server/src/auth/oidc.strategy.ts
+++ b/server/src/auth/oidc.strategy.ts
@@ -1,3 +1,4 @@
+import { Request } from 'express';
 import { UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import {
@@ -33,14 +34,17 @@ export class OidcStrategy extends PassportStrategy(Strategy, 'oidc') {
         redirect_uri: process.env.OAUTH2_CLIENT_REGISTRATION_LOGIN_REDIRECT_URI,
         scope: process.env.OAUTH2_CLIENT_REGISTRATION_LOGIN_SCOPE,
       },
-      passReqToCallback: false,
+      passReqToCallback: true,
       usePKCE: false,
     });
 
     this.client = client;
   }
 
-  async validate(tokenset: TokenSet): Promise<any> {
+  async validate(
+    req: Request & { login: any },
+    tokenset: TokenSet,
+  ): Promise<any> {
     const userinfo: UserinfoResponse = await this.client.userinfo(tokenset);
     try {
       const id_token = tokenset.id_token;
@@ -53,7 +57,14 @@ export class OidcStrategy extends PassportStrategy(Strategy, 'oidc') {
         userinfo,
       };
 
-      return user;
+      return new Promise((resolve, reject) => {
+        req.login(user, (err) => {
+          if (err) {
+            return reject(new UnauthorizedException('Login failed'));
+          }
+          resolve(user);
+        });
+      });
     } catch (err) {
       throw new UnauthorizedException();
     }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -6,16 +6,29 @@ import {
   Param,
   Post,
   Put,
+  UseGuards,
+  Request,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 import { ClassDto, EventDto, InitUserDTO, TimetableDto } from './dto';
 import { UserService } from './user.service';
+import { AuthenticatedGuard } from 'src/auth/authenticated.guard';
 
 @Controller('user')
 export class UserController {
   constructor(private userService: UserService) {}
 
+  @UseGuards(AuthenticatedGuard)
   @Get('profile/:userId')
-  getUserInfo(@Param('userId') userId: string) {
+  getUserInfo(@Request() req, @Param('userId') userId: string) {
+    if (!req.user || userId !== req.user.userinfo.sub) {
+      throw new HttpException(
+        'You can only access your own profile information.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     return this.userService.getUserInfo(userId).then((data) => {
       return {
         status: 'Successsfully returned user profile',
@@ -24,8 +37,16 @@ export class UserController {
     });
   }
 
+  @UseGuards(AuthenticatedGuard)
   @Put('profile')
-  setUserInfo(@Body('data') data: InitUserDTO) {
+  setUserInfo(@Request() req, @Body('data') data: InitUserDTO) {
+    if (!req.user || data.userID !== req.user.userinfo.sub) {
+      throw new HttpException(
+        'You can only edit your own profile information.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     return this.userService.setUserProfile(data).then((res) => {
       return {
         status: 'Successfully created user!',
@@ -34,8 +55,16 @@ export class UserController {
     });
   }
 
+  @UseGuards(AuthenticatedGuard)
   @Get('settings/:userId')
-  getUserSettings(@Param('userId') userId: string) {
+  getUserSettings(@Request() req, @Param('userId') userId: string) {
+    if (!req.user || userId !== req.user.userinfo.sub) {
+      throw new HttpException(
+        'You can only access your own settings.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     return this.userService.getUserSettings(userId).then((data) => {
       return {
         status: 'Successfully found user and their settings!',
@@ -44,12 +73,21 @@ export class UserController {
     });
   }
 
+  @UseGuards(AuthenticatedGuard)
   @Put('settings')
   // @UsePipes(new ValidationPipe({ transform: true }))
   setUserSettings(
+    @Request() req,
     @Body('userId') userId: string,
     @Body('setting') setting: any, //SettingsDto
   ) {
+    if (!req.user || userId !== req.user.userinfo.sub) {
+      throw new HttpException(
+        'You can only edit your own settings.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     return this.userService.setUserSettings(userId, setting).then((data) => {
       return {
         status: 'Successfully edited user settings!',
@@ -58,15 +96,25 @@ export class UserController {
     });
   }
 
+  @UseGuards(AuthenticatedGuard)
   @Get('timetable/:userId')
-  getUserTimetables(@Param('userId') userId: string) {
+  getUserTimetables(@Request() req, @Param('userId') userId: string) {
+    if (!req.user || userId !== req.user.userinfo.sub) {
+      throw new HttpException(
+        'You can only access your own timetables.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     return this.userService.getUserTimetables(userId).then((data) => {
       return { status: `Successfully found user's timetables`, data };
     });
   }
 
+  @UseGuards(AuthenticatedGuard)
   @Post('timetable')
   createUserTimetable(
+    @Request() req,
     @Body('userId') userId: string,
     @Body('selectedCourses') selectedCourses: string[],
     @Body('selectedClasses') selectedClasses: ClassDto[],
@@ -74,6 +122,13 @@ export class UserController {
     @Body('mapKey') mapKey: string,
     @Body('name') timetableName?: string,
   ) {
+    if (!req.user || userId !== req.user.userinfo.sub) {
+      throw new HttpException(
+        'You can only create timetables for your own user.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     return this.userService
       .createUserTimetable(
         userId,
@@ -91,11 +146,21 @@ export class UserController {
       });
   }
 
+  @UseGuards(AuthenticatedGuard)
   @Put('timetable')
   async editUserTimetable(
+    @Request() req,
     @Body('userId') userId: string,
     @Body('timetable') timetable: TimetableDto,
   ) {
+    if (!req.user || userId !== req.user.userinfo.sub) {
+      // This is not really doing anything if the underlying function doesn't make use of the provided userId.
+      throw new HttpException(
+        'You can only edit timetables for your own user.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     return this.userService.editUserTimetable(userId, timetable).then((id) => {
       return {
         status: 'Successfully edited timetable',
@@ -104,18 +169,32 @@ export class UserController {
     });
   }
 
+  @UseGuards(AuthenticatedGuard)
   @Delete('timetable/:timetableId')
-  deleteUserTimetable(@Param('timetableId') timetableId: string) {
-    return this.userService.deleteUserTimetable(timetableId).then((id) => {
-      return {
-        status: 'Successfully deleted timetable',
-        data: { timetableId: id },
-      };
-    });
+  deleteUserTimetable(
+    @Request() req,
+    @Param('timetableId') timetableId: string,
+  ) {
+    return this.userService
+      .deleteUserTimetable(req.user.userinfo.sub, timetableId)
+      .then((id) => {
+        return {
+          status: 'Successfully deleted timetable',
+          data: { timetableId: id },
+        };
+      });
   }
 
+  @UseGuards(AuthenticatedGuard)
   @Get('group/:userId')
-  getUserGroups(@Param('userId') userId: string) {
+  getUserGroups(@Request() req, @Param('userId') userId: string) {
+    if (!req.user || userId !== req.user.userinfo.sub) {
+      throw new HttpException(
+        'You can only access your own groups.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     try {
       return this.userService.getGroups(userId).then((groups) => {
         return {
@@ -128,8 +207,11 @@ export class UserController {
     }
   }
 
+  // Uncomment this and fix perms when adding groups and friends
   @Get('all')
   getAllUsers() {
+    return { status: 'This endpoint is not implemented yet.', data: [] };
+    /*
     try {
       return this.userService.getAllUsers().then((data) => {
         return {
@@ -140,5 +222,6 @@ export class UserController {
     } catch (e) {
       return e;
     }
+    */
   }
 }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import {
   SettingsDto,
   UserDTO,
@@ -253,6 +253,24 @@ export class UserService {
     const eventIds = _timetable.createdEvents.map((event) => event.id);
     const classIds = _timetable.createdEvents.map((c) => c.id);
 
+    const timetable = await this.prisma.timetable.findFirst({
+      where: {
+        id: _timetableId,
+        user: {
+          some: {
+            userID: _userID,
+          },
+        },
+      },
+    });
+
+    if (!timetable) {
+      throw new HttpException(
+        'Not allowed to edit this timetable',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     const update_timetable = this.prisma.timetable.update({
       where: {
         id: _timetableId,
@@ -360,7 +378,28 @@ export class UserService {
     }
   }
 
-  async deleteUserTimetable(_timetableId: string): Promise<string> {
+  async deleteUserTimetable(
+    userID: string,
+    _timetableId: string,
+  ): Promise<string> {
+    const timetable = await this.prisma.timetable.findFirst({
+      where: {
+        id: _timetableId,
+        user: {
+          some: {
+            userID: userID,
+          },
+        },
+      },
+    });
+
+    if (!timetable) {
+      throw new HttpException(
+        'Not allowed to delete this timetable',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     try {
       await this.prisma.timetable.delete({
         where: {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f4212410-e29b-4c5f-9867-7f54a695ff20)

This PR adds authorisation to all backend routes (and disables friend and group routes since we aren't actively using them). This involves:

- Ensuring auth state is correctly held in session, and logging out redirects after clearing said session
- Cookies are sent to the BE from the FE on all API requests
- All user routes are locked behind authentication guards
- All user routes that get/modify data validate any provided user/timetable IDs

Please note that it is still _insane_ that we just send the user ID in the body/URL of these requests rather than just getting it directly from the session, but this is supposed to be a hotfix until the rewrite is done.