### PR TITLE
More aggressively catch corrupted local storage

### DIFF
--- a/client/src/utils/storage.ts
+++ b/client/src/utils/storage.ts
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import defaults from '../constants/defaults';
 import migrateThemes from './migrations/colourTheme';
 import migratePrimaryTimetables from './migrations/primaryTimetables';
@@ -9,7 +8,7 @@ const STORAGE_KEY = 'data';
 // Something is not playing nice and causing local storage to corrupt across signing in/out
 // We are in the process of migrating data to the backend, so this fix should catch people
 // for now and prevent them from seeing a blank page.
-const hasRunArrayCheck = useRef(false);
+let hasRunArrayCheck = false;
 
 const storage = {
   get: (key: string): any => {
@@ -70,7 +69,7 @@ const storage = {
     }
 
     // Un-break an existing issue with migrated data
-    if (!hasRunArrayCheck.current) {
+    if (!hasRunArrayCheck) {
       Object.entries(migrated.timetables).forEach(([term, timetables]) => {
         if (
           !Array.isArray(timetables) ||
@@ -80,7 +79,8 @@ const storage = {
         }
       });
 
-      hasRunArrayCheck.current = true;
+      storage.save(migrated);
+      hasRunArrayCheck = true;
     }
 
     // only do this if version does not exist

--- a/client/src/utils/storage.ts
+++ b/client/src/utils/storage.ts
@@ -1,9 +1,15 @@
+import { useRef } from 'react';
 import defaults from '../constants/defaults';
 import migrateThemes from './migrations/colourTheme';
 import migratePrimaryTimetables from './migrations/primaryTimetables';
 import { createDefaultTimetable } from './timetableHelpers';
 
 const STORAGE_KEY = 'data';
+
+// Something is not playing nice and causing local storage to corrupt across signing in/out
+// We are in the process of migrating data to the backend, so this fix should catch people
+// for now and prevent them from seeing a blank page.
+const hasRunArrayCheck = useRef(false);
 
 const storage = {
   get: (key: string): any => {
@@ -64,7 +70,7 @@ const storage = {
     }
 
     // Un-break an existing issue with migrated data
-    if (migrated.version == null || migrated.version < 2) {
+    if (!hasRunArrayCheck.current) {
       Object.entries(migrated.timetables).forEach(([term, timetables]) => {
         if (
           !Array.isArray(timetables) ||
@@ -73,6 +79,8 @@ const storage = {
           migrated.timetables[term] = createDefaultTimetable('');
         }
       });
+
+      hasRunArrayCheck.current = true;
     }
 
     // only do this if version does not exist


### PR DESCRIPTION
### Description 🧾

Motivated by seeing our second user with corrupted storage, already migrated to version 2. Something is very wrong here - we should look at where new terms get created/added, as well as all of the code that syncs data _from_ the user database to local storage. In the meantime/since we are replacing that code anyway, my fairly destructive check that gets users out of binds can be run once per refresh to try and get users out of this issue.

### Testing

Not tested yet - I will have more time later this week.
