### PR TITLE
Update team.json

### DIFF
--- a/client/team.json
+++ b/client/team.json
@@ -1,4 +1,4 @@
 {
   "directors": ["Lucas Harvey", "Mark Tran"],
-  "subcommittee": ["Ana Kiperas, Ben Quin, Fritz Rehde, Jason Poon, Kailash Siva, Meredith Zhang, Sunny Chen"]
+  "subcommittee": ["Ana Kiperas, Ben Quin, Fritz Rehde, Jason Poon, Kai Fox, Kailash Siva, Meredith Zhang, Sunny Chen, Tet Nay Lin"]
 }


### PR DESCRIPTION
Updated `team.json` file to include Kai & Tet. Reflected in front end in the 'about' section.

Before
<img width="573" height="221" alt="Screenshot 2025-07-24 at 5 40 04 pm" src="https://github.com/user-attachments/assets/7e657fa0-bb5e-44ef-b772-8016caed6e69" />

After
<img width="573" height="217" alt="Screenshot 2025-07-24 at 5 38 10 pm" src="https://github.com/user-attachments/assets/3041668f-4c82-4ec0-8586-76833c8cfe88" />


