### PR TITLE
Fix Backend Timetable Routes based on IDs

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -128,6 +128,7 @@ export class AuthService {
             name: timetableName,
             year: year,
             term,
+            primary: true,
           },
         });
       }

--- a/server/src/timetable/timetable.controller.ts
+++ b/server/src/timetable/timetable.controller.ts
@@ -14,7 +14,6 @@ import {
 import { TimetableService } from './timetable.service';
 import { AuthenticatedGuard } from 'src/auth/authenticated.guard';
 import { AuthenticatedRequest } from 'src/auth/auth.controller';
-import { AddCourseDto } from './types';
 
 @Controller('user/timetables')
 export class TimetableController {
@@ -66,15 +65,8 @@ export class TimetableController {
   async deleteTimetable(
     @Req() req: AuthenticatedRequest,
     @Param('id') timetableId: string,
-    @Query('year') year: string,
-    @Query('term') term: string,
   ) {
-    await this.timetableService.deleteTimetable(
-      req.user.id,
-      timetableId,
-      Number(year),
-      term,
-    );
+    await this.timetableService.deleteTimetable(req.user.id, timetableId);
   }
 
   @Patch(':id/rename')
@@ -96,9 +88,8 @@ export class TimetableController {
   async makePrimary(
     @Req() req: AuthenticatedRequest,
     @Param('id') timetableId: string,
-    @Body() data: { year: number; term: string },
   ) {
-    await this.timetableService.makePrimary(req.user.id, timetableId, data);
+    await this.timetableService.makePrimary(req.user.id, timetableId);
   }
 
   @Get('courses/:timetableId')
@@ -116,13 +107,13 @@ export class TimetableController {
     @Req() req: AuthenticatedRequest,
     @Param('timetableId') timetableId: string,
     @Param('courseId') courseId: string,
-    @Body() addCourseDto: AddCourseDto,
+    @Body('colour') colour: string,
   ) {
     await this.timetableService.addCourse(
       req.user.id,
       timetableId,
       courseId,
-      addCourseDto,
+      colour,
     );
     return HttpStatus.CREATED;
   }

--- a/server/src/timetable/timetable.service.ts
+++ b/server/src/timetable/timetable.service.ts
@@ -88,7 +88,7 @@ export class TimetableService {
     );
     validate(
       courseExistsOnGraphQL,
-      'Course does not exist' + `in term ${timetable.term}` + courseId,
+      'Course does not exist',
       HttpStatus.NOT_FOUND,
     );
 

--- a/server/src/timetable/timetable.service.ts
+++ b/server/src/timetable/timetable.service.ts
@@ -2,7 +2,7 @@ import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { GraphqlService } from 'src/graphql/graphql.service';
 import { validate } from 'src/utils/validate';
-import { AddCourseDto, CourseDetails, UserTimetable } from './types';
+import { CourseDetails, UserTimetable } from './types';
 import type { ClassDetails } from 'src/graphql/types';
 
 @Injectable()
@@ -75,23 +75,22 @@ export class TimetableService {
     userId: string,
     timetableId: string,
     courseId: string,
-    addCourseDto: AddCourseDto,
+    colour: string,
   ): Promise<void> {
+    const timetable = await this.prisma.timetable.findUniqueOrThrow({
+      select: { term: true },
+      where: { id: timetableId, userId },
+    });
+
     const courseExistsOnGraphQL = await this.graphqlService.courseExists(
       courseId,
-      addCourseDto.term,
+      `%${timetable.term}%`,
     );
     validate(
       courseExistsOnGraphQL,
-      'Course does not exist',
+      'Course does not exist' + `in term ${timetable.term}` + courseId,
       HttpStatus.NOT_FOUND,
     );
-
-    const timetableExists = await this.isTimetableOwnedByUser(
-      userId,
-      timetableId,
-    );
-    validate(timetableExists, 'Timetable does not exist', HttpStatus.NOT_FOUND);
 
     const courseInTimetable = await this.isCourseInTimetable(
       timetableId,
@@ -103,13 +102,13 @@ export class TimetableService {
       HttpStatus.CONFLICT,
     );
 
-    const colourValid = this.isColourCodeValid(addCourseDto.colour);
+    const colourValid = this.isColourCodeValid(colour);
     validate(colourValid, 'Colour code is not valid', HttpStatus.BAD_REQUEST);
 
     await this.prisma.course.create({
       data: {
         courseId,
-        colour: addCourseDto.colour,
+        colour: colour,
         selectedClasses: [],
         timetable: { connect: { id: timetableId } },
       },
@@ -355,14 +354,14 @@ export class TimetableService {
     return timetable.id;
   }
 
-  async deleteTimetable(
-    userId: string,
-    timetableId: string,
-    year: number,
-    term: string,
-  ): Promise<void> {
+  async deleteTimetable(userId: string, timetableId: string): Promise<void> {
+    const timetable = await this.prisma.timetable.findUniqueOrThrow({
+      select: { primary: true, year: true, term: true },
+      where: { id: timetableId, userId },
+    });
+
     const numTimetables = await this.prisma.timetable.count({
-      where: { userId, year, term },
+      where: { userId, year: timetable.year, term: timetable.term },
     });
 
     if (numTimetables <= 1) {
@@ -371,10 +370,6 @@ export class TimetableService {
         HttpStatus.NOT_FOUND,
       );
     }
-
-    const timetable = await this.prisma.timetable.findFirst({
-      where: { id: timetableId, userId },
-    });
 
     if (!timetable) {
       throw new HttpException(
@@ -404,12 +399,9 @@ export class TimetableService {
     });
   }
 
-  async makePrimary(
-    userId: string,
-    timetableId: string,
-    data: { year: number; term: string },
-  ): Promise<void> {
+  async makePrimary(userId: string, timetableId: string): Promise<void> {
     const timetable = await this.prisma.timetable.findFirst({
+      select: { year: true, term: true },
       where: { id: timetableId, userId },
     });
 
@@ -425,8 +417,8 @@ export class TimetableService {
         where: {
           userId,
           primary: true,
-          year: data.year,
-          term: data.term,
+          year: timetable.year,
+          term: timetable.term,
         },
         data: { primary: false },
       }),

--- a/server/src/timetable/timetable.service.ts
+++ b/server/src/timetable/timetable.service.ts
@@ -84,7 +84,7 @@ export class TimetableService {
 
     const courseExistsOnGraphQL = await this.graphqlService.courseExists(
       courseId,
-      `%${timetable.term}%`,
+      timetable.term,
     );
     validate(
       courseExistsOnGraphQL,

--- a/server/src/timetable/types.ts
+++ b/server/src/timetable/types.ts
@@ -1,7 +1,3 @@
-export class AddCourseDto {
-  term: string;
-  colour: string;
-}
 export class CourseDetails {
   id: string;
   selectedClasses: string[];


### PR DESCRIPTION
### Description 🧾

- Problem:
  - Currently some of the backend routes are handling using both entity IDs and terms.
    1. `addCourse`
    2. `makePrimary`
    3. `deleteTimetable`
  - Causing a case of the selected Ids are not matching to its corresponding term. 
- Solution:
  - Fix it by primary based on the given IDs instead of having both terms and IDs as indicator
### Testing

Using Postman to test the API routes calling properly

### Checklist

- [ ] 📍 You have assigned yourself to this pull request.
- [ ] 🔗 You have linked an issue to which this pull request closes.
- [ ] 💭 Leave any relevant specific directions to reviewers.
- [ ] 👀 No secrets in clear text in the pull request.
- [ ] 🎟️ To categorise release notes, the pull request should be labelled with at least one of these labels:
  - `feature`: for application feature improvement or new features
  - `bug`: fixing something that previously wasn't working
  - `dev`: development-side related changes
  - `docker`: updates to the Docker code
  - `setup`: changes to the setup/infrastructure of the codebase
  - `test`: updates to internal testing
