### PR TITLE
chore(actions): remove repo dispatch environment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,7 +112,6 @@ jobs:
       cancel-in-progress: true
     timeout-minutes: 10
     permissions: {}
-    environment: production
 
     steps:
       - name: Create GitHub App token


### PR DESCRIPTION
## What This Does
This PR removes the `environment: production` setting from the `repo_dispatch` job in `.github/workflows/docker.yml`.

That environment was only added to satisfy the old local `zizmor` gate. The local verifier now ignores `secrets-outside-env`, so the workflow no longer needs an environment binding for the GitHub App private key.

## Verification
Scoped to `.github/workflows/docker.yml` only:
- `tmp/verify-workflow.sh /home/risu/.ghr/github.com/devsoc-unsw/notangles .github/workflows/docker.yml`
