### PR TITLE
revert: restore node 22 after ci bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: ${{ matrix.component }}/pnpm-lock.yaml
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,5 @@
 # Grab the latest Node base image
-FROM node:24.14.1-alpine AS builder
+FROM node:22.16.0-alpine AS builder
 RUN npm i -g pnpm
 
 # Set the current working directory inside the container

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 # Dependency versions should be pinned
-FROM node:24.14.1-alpine AS builder
+FROM node:22.16.0-alpine AS builder
 RUN apk add --no-cache openssl
 
 RUN npm i -g pnpm
@@ -14,7 +14,7 @@ RUN pnpm i --frozen-lockfile
 COPY . .
 RUN pnpm run build
 
-FROM node:24.14.1-alpine
+FROM node:22.16.0-alpine
 WORKDIR /server
 RUN npm i -g pnpm
 


### PR DESCRIPTION
## Summary
Revert the Node version bumps introduced in #1106 while keeping the newer GitHub Action versions.

## Changes
- restore .github/workflows/ci.yml to node-version '22'
- restore client/Dockerfile to node:22.16.0-alpine
- restore server/Dockerfile to node:22.16.0-alpine

## Context
Commit 77966cb7 (chore(deps): update ci-actions) bumped CI and Docker Node versions from 22 to 24. This PR reverts only those version changes.