### PR TITLE
Revert "chore(actions): replace deployment PAT with app dispatch (#1110)"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,28 +5,20 @@ on:
       - dev
       - staging
 
-permissions: {}
-
 env:
+  ENVIRONMENT: ${{ github.ref_name == 'dev' && 'prod' || 'staging' }}
   IMAGE_NAME: ${{ github.ref_name == 'dev' && 'notangles' || 'notangles-staging' }}
 
 jobs:
   build-client:
     name: 'Build (Client)'
     runs-on: ubuntu-latest
-    concurrency:
-      group: docker-build-client-${{ github.ref }}
-      cancel-in-progress: true
-    timeout-minutes: 30
-    environment: ${{ github.ref_name == 'dev' && 'Production' || 'staging' }}
     permissions:
       contents: read
-      packages: write # Required to publish container tags to GHCR.
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
@@ -38,7 +30,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ github.token }}
+          password: ${{ secrets.GH_TOKEN }}
       - name: Build and push Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
@@ -54,13 +46,10 @@ jobs:
           tags: |
             ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-client:${{ github.sha }}
             ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-client:latest
+          labels: ${{ steps.meta.outputs.labels }}
   build:
     name: 'Build (${{ matrix.component }})'
     runs-on: ubuntu-latest
-    concurrency:
-      group: docker-build-${{ matrix.component }}-${{ github.ref }}
-      cancel-in-progress: true
-    timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:
@@ -72,12 +61,10 @@ jobs:
             name: auto-timetabler-server
     permissions:
       contents: read
-      packages: write # Required to publish container tags to GHCR.
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
@@ -89,11 +76,11 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ github.token }}
+          password: ${{ secrets.GH_TOKEN }}
       - name: Build and push Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
-          context: ${{ matrix.component }} # zizmor: ignore[template-injection] matrix values are hard-coded in this workflow
+          context: ${{ matrix.component }}
           push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/dev' }}
           platforms: linux/amd64
           file: ${{ matrix.component }}/Dockerfile
@@ -102,54 +89,36 @@ jobs:
           tags: |
             ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-${{ matrix.name }}:${{ github.sha }}
             ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-${{ matrix.name }}:latest
-  repo_dispatch:
-    name: Notify deployment repo
+          labels: ${{ steps.meta.outputs.labels }}
+  deploy:
+    name: Deploy (CD)
     runs-on: ubuntu-latest
     needs: [build-client, build]
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/dev' }}
-    concurrency:
-      group: docker-repo-dispatch-${{ github.ref }}
-      cancel-in-progress: true
-    timeout-minutes: 10
-    permissions: {}
+    concurrency: production
     environment: production
 
     steps:
-      - name: Create GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          app-id: ${{ vars.IMAGE_UPDATER_APP_ID }}
-          private-key: ${{ secrets.IMAGE_UPDATER_APP_PRIVATE_KEY }}
-          owner: devsoc-unsw
-          repositories: deployment
-          permission-actions: write
-
-      - name: Send workflow_dispatch
+          repository: devsoc-unsw/deployment
+          token: ${{ secrets.GH_TOKEN }}
+          ref: dev
+      - name: Install yq - portable yaml processor
+        uses: mikefarah/yq@v4.44.2
+      - name: Update deployment
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          IMAGE_TAG: ${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          updates_json="$(
-            jq -cn \
-              --arg sha "${IMAGE_TAG}" \
-              '[
-                {image: "ghcr.io/devsoc-unsw/notangles-client", tag: $sha},
-                {image: "ghcr.io/devsoc-unsw/notangles-backend", tag: $sha},
-                {image: "ghcr.io/devsoc-unsw/notangles-auto-timetabler-server", tag: $sha}
-              ]'
-          )"
-          payload_json="$(
-            jq -cn \
-              --arg ref "dev" \
-              --arg updates "${updates_json}" \
-              '{ref: $ref, inputs: {updates: $updates}}'
-          )"
-
-          curl --fail-with-body \
-            -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            https://api.github.com/repos/devsoc-unsw/deployment/actions/workflows/dispatch-image-update.yml/dispatches \
-            -d "${payload_json}"
+          git config user.name "CSESoc CD"
+          git config user.email "technical@csesoc.org.au"
+          git checkout -b update/${{ env.IMAGE_NAME }}/${{ github.sha }}
+          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-client:${{ github.sha }}"' projects/notangles/${{ env.ENVIRONMENT }}/deploy-frontend.yml
+          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-backend:${{ github.sha }}"' projects/notangles/${{ env.ENVIRONMENT }}/deploy-backend.yml
+          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-auto-timetabler-server:${{ github.sha }}"' projects/notangles/${{ env.ENVIRONMENT }}/deploy-auto-timetabler.yml
+          git add . 
+          git commit -m "feat(${{ env.IMAGE_NAME }}): update images" 
+          git push -u origin update/${{ env.IMAGE_NAME }}/${{ github.sha }}
+          gh pr create -B dev --title "feat(${{ env.IMAGE_NAME }}): update images" --body "Updates the images for the ${{ env.IMAGE_NAME }} deployment to commit devsoc-unsw/${{ env.IMAGE_NAME }}@${{ github.sha }}." > URL
+          gh pr merge $(cat URL) --squash -d


### PR DESCRIPTION
## Summary
Revert #1110 and restore the pre-app-dispatch deployment flow in `.github/workflows/docker.yml`.

## Changes
- restore the old `deploy` job that checks out `devsoc-unsw/deployment` and updates manifests directly
- switch container registry auth back from `github.token` to `secrets.GH_TOKEN`
- remove the `repo_dispatch` GitHub App workflow-dispatch flow added in `#1110`
- remove the top-level permissions block, job concurrency/timeouts, and other workflow reshaping introduced in `#1110`
- keep the later action version bumps from `#1106` where they overlapped with this revert

## Verification
- `yq eval '.' .github/workflows/docker.yml > /dev/null`
- `actionlint -color .github/workflows/docker.yml` currently fails after this revert because the restored pre-`#1110` workflow still references `steps.meta.outputs.labels` in two jobs and triggers a pre-existing `shellcheck` warning in the deploy script
