### PR TITLE
chore(actions): unpin docker workflow actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,21 +18,21 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@v3
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GH_TOKEN }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@v6
         with:
           context: client
           push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/dev' }}
@@ -64,21 +64,21 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@v3
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GH_TOKEN }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.component }}
           push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/dev' }}


### PR DESCRIPTION
## Summary
Unpin the Docker workflow action references and switch them back to major-version tags only.

## Changes
- change `actions/checkout` from a pinned commit SHA back to `@v4` in both build jobs
- change `docker/setup-qemu-action` from a pinned commit SHA back to `@v3`
- change `docker/setup-buildx-action` from a pinned commit SHA back to `@v3`
- change `docker/login-action` from a pinned commit SHA back to `@v3`
- change `docker/build-push-action` from a pinned commit SHA back to `@v6`
- leave the rest of the workflow shape unchanged

## Verification
- `yq eval '.' .github/workflows/docker.yml > /dev/null`
- `rg -n "uses: .*@[0-9a-f]{40}" .github/workflows/docker.yml -S`
- `actionlint -color .github/workflows/docker.yml` still fails on the pre-existing `steps.meta.outputs.labels` references and the existing deploy-script shellcheck warning restored by `#1116`
