### PR TITLE
feat(auto): replace CP-SAT runtime with Clingo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,22 @@ jobs:
         run: pnpm run build
         working-directory: ${{ matrix.component }}
 
-  check-auto-tt-deps:
-    name: 'Check Dependencies (auto-timetabler-server)'
+  test-auto-timetabler:
+    name: 'Test auto-timetabler'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10.4'
+          python-version: '3.10'
           cache: 'pip'
+          cache-dependency-path: auto_server/requirements-dev.txt
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-dev.txt
+        working-directory: auto_server
+
+      - name: Test
+        run: python -m unittest discover -s tests -v
         working-directory: auto_server

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ typings/
 .DS_Store
 
 */venv/*
+.hypothesis/

--- a/auto_server/README.md
+++ b/auto_server/README.md
@@ -6,14 +6,15 @@ The Notangles autotimetabler returns a possible timetable that matches the user'
 
 The server has been verified to work with:
 
-- Python v3.8.10
-- pip v21.2.4
+- Python 3.10
 
 First, in the root server directory `auto_server` create a virtual environment with `python3 -m venv env`.
 
 Activate the virtual environment by running `source env/bin/activate`
 
 Finally, in your virtual environment, run `python3 -m pip install -r requirements.txt` to install all the dependencies.
+
+For development and tests, install `requirements-dev.txt` instead.
 
 ## Running
 
@@ -25,10 +26,22 @@ The real values of these environment variables are only required when the app is
 
 The Notangles autotimetabler uses:
 
-- [Google OR-Tools](https://developers.google.com/optimization)
+- [Clingo](https://potassco.org/clingo/)
 - [gRPC](https://grpc.io/)
 
 ## Logic
 
-- The autotimetabler uses Google OR-Tools' set of constraint programming algorithms to generate a possible arrangement of classes based on the user's provided constraints.
-- It then returns this result to the Notangles server using gRPC (Remote Procedure Calls)
+- The autotimetabler uses Clingo to choose clash-free classes and rank the choices against the user's preferences.
+- It returns the best choice to the Notangles server through the existing gRPC contract.
+
+## Testing
+
+Run the Python and generated differential tests with:
+
+```sh
+python3 -m unittest discover -s tests -v
+```
+
+See [the solver design](../docs/clingo-autotimetabler.md) and
+[the measured comparison](../docs/clingo-autotimetabler-benchmark.md) for the
+replacement evidence.

--- a/auto_server/benchmarks/compare_solvers.py
+++ b/auto_server/benchmarks/compare_solvers.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+import argparse
+import contextlib
+import io
+import json
+import sys
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import auto
+import clingo_solver
+
+
+@dataclass
+class Period:
+    periodsPerClass: int
+    periodTimes: list[float]
+    durations: list[float]
+
+
+@dataclass
+class Request:
+    start: int
+    end: int
+    days: str
+    gap: int
+    maxdays: int
+    periodInfo: list[Period]
+
+
+@dataclass(frozen=True)
+class Workload:
+    name: str
+    activities: int
+    options: int
+    dense: bool
+
+
+WORKLOADS = (
+    Workload("representative-small", activities=4, options=8, dense=False),
+    Workload("representative-medium", activities=8, options=12, dense=False),
+    Workload("collision-dense", activities=12, options=20, dense=True),
+)
+
+
+def make_request(workload: Workload) -> Request:
+    periods = []
+    for activity in range(workload.activities):
+        alternatives = []
+        for option in range(workload.options):
+            if workload.dense and option < workload.options - 2:
+                day = option % 2 + 1
+                slot = 18 + option % 4
+            else:
+                day = (activity + option) % 5 + 1
+                slot = 16 + (activity * 3 + option * 5) % 24
+            alternatives.extend((day, slot / 2))
+        periods.append(
+            Period(
+                periodsPerClass=1,
+                periodTimes=alternatives,
+                durations=[1],
+            )
+        )
+    return Request(
+        start=9,
+        end=18,
+        days="12345",
+        gap=1 if workload.dense else 0,
+        maxdays=2 if workload.dense else 3,
+        periodInfo=periods,
+    )
+
+
+def run_solver(name: str, request: Request) -> None:
+    if name == "ortools":
+        with contextlib.redirect_stdout(io.StringIO()):
+            auto.sols(request)
+        return
+    preference_mode = "legacy" if name == "clingo-legacy" else "hierarchical"
+    clingo_solver.solve(request, max_solutions=3, preference_mode=preference_mode)
+
+
+def benchmark(name: str, request: Request, repeats: int) -> dict[str, float]:
+    run_solver(name, request)
+    durations = []
+    for _ in range(repeats):
+        started = time.perf_counter()
+        run_solver(name, request)
+        durations.append((time.perf_counter() - started) * 1000)
+    ordered = sorted(durations)
+    p95_index = min(len(ordered) - 1, int(len(ordered) * 0.95))
+    return {
+        "median_ms": round(statistics.median(ordered), 3),
+        "p95_ms": round(ordered[p95_index], 3),
+        "minimum_ms": round(ordered[0], 3),
+        "maximum_ms": round(ordered[-1], 3),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--solver",
+        choices=("ortools", "clingo-legacy", "clingo-hierarchical"),
+        required=True,
+    )
+    parser.add_argument("--repeats", type=int, default=30)
+    args = parser.parse_args()
+    if args.repeats < 1:
+        parser.error("--repeats must be at least 1")
+
+    output = {
+        workload.name: benchmark(
+            args.solver,
+            make_request(workload),
+            args.repeats,
+        )
+        for workload in WORKLOADS
+    }
+    print(json.dumps({"solver": args.solver, "results": output}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/auto_server/clingo_solver.py
+++ b/auto_server/clingo_solver.py
@@ -1,0 +1,300 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import clingo
+
+TIME_MULT = 2
+WEEKDAYS = range(1, 6)
+DEFAULT_DURATION = 1
+MAX_SOLUTIONS = 3
+
+MODEL_PATH = Path(__file__).with_name("timetable.lp")
+
+
+@dataclass(frozen=True)
+class Meeting:
+    activity: int
+    option: int
+    meeting: int
+    day: int
+    start: int
+    duration: int
+    code: int
+    primary: bool
+
+
+@dataclass(frozen=True)
+class PreferenceViolation:
+    code: str
+    priority: int
+    count: int
+    message: str
+
+
+@dataclass(frozen=True)
+class TimetableSolution:
+    times: tuple[int, ...]
+    options: tuple[int, ...]
+    cost: tuple[int, ...]
+    violations: tuple[PreferenceViolation, ...]
+
+    @property
+    def optimal(self) -> bool:
+        return not self.violations
+
+
+@dataclass(frozen=True)
+class TimetableResult:
+    solutions: tuple[TimetableSolution, ...]
+
+    @property
+    def primary(self) -> TimetableSolution | None:
+        return self.solutions[0] if self.solutions else None
+
+
+@dataclass(frozen=True)
+class Problem:
+    earliest: int
+    latest: int
+    gap: int
+    allowed_days: tuple[int, ...]
+    max_days: int
+    meetings: tuple[Meeting, ...]
+    option_count: tuple[int, ...]
+
+
+def _half_hours(value: float) -> int:
+    scaled = value * TIME_MULT
+    if not float(scaled).is_integer():
+        raise ValueError("times and durations must use half-hour increments")
+    return int(scaled)
+
+
+def _read_field(value, camel_case: str, snake_case: str):
+    if hasattr(value, camel_case):
+        return getattr(value, camel_case)
+    return getattr(value, snake_case)
+
+
+def _normalise_period(
+    period, activity: int, next_meeting: int
+) -> tuple[list[Meeting], int, int]:
+    periods_per_class = int(_read_field(period, "periodsPerClass", "periods_per_class"))
+    period_times = list(_read_field(period, "periodTimes", "period_times"))
+    durations = list(_read_field(period, "durations", "durations"))
+
+    if periods_per_class <= 0:
+        periods_per_class = 1
+        durations = [DEFAULT_DURATION]
+
+    values_per_option = periods_per_class * 2
+    if not period_times or len(period_times) % values_per_option:
+        raise ValueError(
+            f"activity {activity} periodTimes must contain complete class alternatives"
+        )
+    if len(durations) != periods_per_class:
+        raise ValueError(
+            f"activity {activity} durations must contain one value per period"
+        )
+
+    option_count = len(period_times) // values_per_option
+    meetings: list[Meeting] = []
+    for option in range(option_count):
+        offset = option * values_per_option
+        for period_index in range(periods_per_class):
+            day = int(period_times[offset + period_index * 2])
+            start = _half_hours(period_times[offset + period_index * 2 + 1])
+            duration = _half_hours(durations[period_index])
+            if day not in WEEKDAYS:
+                raise ValueError(f"activity {activity} contains invalid weekday {day}")
+            if start < 0 or start >= 24 * TIME_MULT:
+                raise ValueError(f"activity {activity} contains invalid start time")
+            if duration <= 0 or start + duration > 24 * TIME_MULT:
+                raise ValueError(f"activity {activity} contains invalid duration")
+            meetings.append(
+                Meeting(
+                    activity=activity,
+                    option=option,
+                    meeting=next_meeting,
+                    day=day,
+                    start=start,
+                    duration=duration,
+                    code=day * 100 + start,
+                    primary=period_index == 0,
+                )
+            )
+            next_meeting += 1
+    return meetings, option_count, next_meeting
+
+
+def normalise_request(request) -> Problem:
+    if not 0 <= request.start <= request.end <= 24:
+        raise ValueError("start and end must describe a valid daily time window")
+    if not 0 <= request.gap <= 24:
+        raise ValueError("gap must be between 0 and 24 hours")
+    if not 1 <= request.maxdays <= len(tuple(WEEKDAYS)):
+        raise ValueError("maxdays must be between 1 and 5")
+
+    try:
+        allowed_days = tuple(sorted({int(day) for day in request.days}))
+    except (TypeError, ValueError) as error:
+        raise ValueError("days must contain only weekdays 1 through 5") from error
+    if not allowed_days:
+        raise ValueError("days must contain at least one weekday")
+    if any(day not in WEEKDAYS for day in allowed_days):
+        raise ValueError("days must contain only weekdays 1 through 5")
+
+    all_meetings: list[Meeting] = []
+    option_counts: list[int] = []
+    next_meeting = 0
+    period_info = _read_field(request, "periodInfo", "period_info")
+    if not period_info:
+        raise ValueError("periodInfo must contain at least one activity")
+    for activity, period in enumerate(period_info):
+        meetings, option_count, next_meeting = _normalise_period(
+            period, activity, next_meeting
+        )
+        all_meetings.extend(meetings)
+        option_counts.append(option_count)
+
+    max_days = min(
+        max(int(request.maxdays), 0), len(allowed_days), len(tuple(WEEKDAYS))
+    )
+    return Problem(
+        earliest=_half_hours(request.start),
+        latest=_half_hours(request.end),
+        gap=_half_hours(request.gap),
+        allowed_days=allowed_days,
+        max_days=max_days,
+        meetings=tuple(all_meetings),
+        option_count=tuple(option_counts),
+    )
+
+
+def _facts(problem: Problem, preference_mode: str) -> str:
+    lines = [
+        f"earliest({problem.earliest}).",
+        f"latest({problem.latest}).",
+        f"gap({problem.gap}).",
+        f"max_days({problem.max_days}).",
+        "weekday(1..5).",
+        f"{preference_mode}.",
+    ]
+    lines.extend(f"allowed_day({day})." for day in problem.allowed_days)
+    for activity, count in enumerate(problem.option_count):
+        lines.append(f"activity({activity}).")
+        lines.extend(f"option({activity},{option})." for option in range(count))
+    lines.extend(
+        "meeting("
+        f"{meeting.activity},{meeting.option},{meeting.meeting},{meeting.day},"
+        f"{meeting.start},{meeting.duration},{meeting.code},{int(meeting.primary)}"
+        ")."
+        for meeting in problem.meetings
+    )
+    return "\n".join(lines)
+
+
+def _count_symbols(symbols: Iterable[clingo.Symbol], name: str) -> int:
+    return sum(1 for symbol in symbols if symbol.name == name)
+
+
+def _violations(symbols: Sequence[clingo.Symbol]) -> tuple[PreferenceViolation, ...]:
+    definitions = (
+        (
+            "disallowed_day",
+            "outside_selected_days",
+            3,
+            "meeting outside the selected weekdays",
+        ),
+        (
+            "outside_compact_day",
+            "exceeds_maximum_days",
+            2,
+            "meeting outside the best set of requested campus days",
+        ),
+        (
+            "before_earliest",
+            "before_earliest_start",
+            1,
+            "day containing a meeting before the preferred start time",
+        ),
+        (
+            "after_latest",
+            "after_latest_end",
+            1,
+            "day containing a meeting after the preferred end time",
+        ),
+    )
+    violations = []
+    for predicate, code, priority, description in definitions:
+        count = _count_symbols(symbols, predicate)
+        if count:
+            violations.append(
+                PreferenceViolation(
+                    code=code,
+                    priority=priority,
+                    count=count,
+                    message=f"{count} {description}{'' if count == 1 else 's'}",
+                )
+            )
+    return tuple(violations)
+
+
+def _decode(
+    problem: Problem, symbols: Sequence[clingo.Symbol], cost: Sequence[int]
+) -> TimetableSolution:
+    choices = {
+        symbol.arguments[0].number: symbol.arguments[1].number
+        for symbol in symbols
+        if symbol.name == "chosen"
+    }
+    primary_codes = {
+        (meeting.activity, meeting.option): meeting.code
+        for meeting in problem.meetings
+        if meeting.primary
+    }
+    options = tuple(choices[activity] for activity in range(len(problem.option_count)))
+    times = tuple(
+        primary_codes[(activity, option)] for activity, option in enumerate(options)
+    )
+    return TimetableSolution(
+        times=times,
+        options=options,
+        cost=tuple(cost),
+        violations=_violations(symbols),
+    )
+
+
+def solve(
+    request,
+    max_solutions: int = MAX_SOLUTIONS,
+    preference_mode: str = "hierarchical",
+) -> TimetableResult:
+    if max_solutions < 1:
+        raise ValueError("max_solutions must be at least 1")
+    if preference_mode not in {"hierarchical", "legacy"}:
+        raise ValueError("preference_mode must be hierarchical or legacy")
+
+    problem = normalise_request(request)
+    control = clingo.Control(["0", "--opt-mode=optN", "--seed=0"])
+    control.load(str(MODEL_PATH))
+    control.add("base", [], _facts(problem, preference_mode))
+    control.ground([("base", [])])
+
+    solutions: dict[tuple[int, ...], TimetableSolution] = {}
+
+    def on_model(model: clingo.Model) -> bool:
+        if model.cost and not model.optimality_proven:
+            return True
+        symbols = model.symbols(shown=True)
+        solution = _decode(problem, symbols, model.cost)
+        solutions.setdefault(solution.times, solution)
+        return len(solutions) < max_solutions
+
+    result = control.solve(on_model=on_model)
+    if not result.satisfiable:
+        return TimetableResult(solutions=())
+
+    ordered = tuple(solutions[times] for times in sorted(solutions))
+    return TimetableResult(solutions=ordered)

--- a/auto_server/requirements-dev.txt
+++ b/auto_server/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+grpcio-tools==1.65.1
+hypothesis==6.135.26
+ortools==9.10.4067

--- a/auto_server/requirements.txt
+++ b/auto_server/requirements.txt
@@ -1,13 +1,3 @@
-absl-py==2.1.0
-certifi==2025.1.31
+clingo==5.8.0
 grpcio==1.65.1
-immutabledict==4.2.0
-numpy==2.1.1
-ortools==9.10.4067
-pandas==2.2.2
 protobuf==5.27.2
-python-dateutil==2.9.0.post0
-pytz==2025.2
-six==1.16.0
-tzdata==2025.2
-urllib3==2.2.2

--- a/auto_server/server.py
+++ b/auto_server/server.py
@@ -1,39 +1,53 @@
 import logging
-import os
 from concurrent import futures
 
 import grpc
 
-import auto
 import autotimetabler_pb2
 import autotimetabler_pb2_grpc
+import clingo_solver
 
 # the command to compile proto file --> python -m grpc_tools.protoc -I./ --python_out=. --grpc_python_out=. ./autotimetabler.proto
 
 
 class AutoTimetablerServicer(autotimetabler_pb2_grpc.AutoTimetablerServicer):
-    def FindBestTimetable(self, request, _context):
-        """Passes request to auto algorithm.
+    def FindBestTimetable(self, request, context):
+        """Finds the best timetable.
 
         Args:
             request (request): grpc request message
 
         Returns:
-            [int]: times
+            AutoTimetableResponse: The best result using the existing wire format.
         """
         logging.info("Finding a timetable!")
-        allocatedTimes, isOptimal = auto.sols(request)
-        logging.info(allocatedTimes)
-        return autotimetabler_pb2.AutoTimetableResponse(times=allocatedTimes, optimal=isOptimal)
+        try:
+            result = clingo_solver.solve(request)
+        except ValueError as error:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(error))
+
+        primary = result.primary
+        if primary is None:
+            return autotimetabler_pb2.AutoTimetableResponse()
+
+        logging.info("Found an optimal timetable")
+        return autotimetabler_pb2.AutoTimetableResponse(
+            times=primary.times,
+            optimal=primary.optimal,
+        )
+
 
 def serve():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    autotimetabler_pb2_grpc.add_AutoTimetablerServicer_to_server(AutoTimetablerServicer(), server)
-    server.add_insecure_port('[::]:50051')
+    autotimetabler_pb2_grpc.add_AutoTimetablerServicer_to_server(
+        AutoTimetablerServicer(), server
+    )
+    server.add_insecure_port("[::]:50051")
     server.start()
     logging.info("Server started, listening on port 50051")
     server.wait_for_termination()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     serve()

--- a/auto_server/tests/__init__.py
+++ b/auto_server/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Autotimetabler tests."""

--- a/auto_server/tests/test_clingo_solver.py
+++ b/auto_server/tests/test_clingo_solver.py
@@ -1,0 +1,403 @@
+import contextlib
+import io
+import re
+import unittest
+from dataclasses import dataclass
+
+import grpc
+from hypothesis import given, settings, strategies as st
+
+import auto
+import autotimetabler_pb2
+from clingo_solver import normalise_request, solve
+from server import AutoTimetablerServicer
+
+
+@dataclass
+class Period:
+    periodsPerClass: int
+    periodTimes: list[float]
+    durations: list[float]
+
+
+@dataclass
+class Request:
+    start: int
+    end: int
+    days: str
+    gap: int
+    maxdays: int
+    periodInfo: list[Period]
+
+
+class RpcAbort(Exception):
+    pass
+
+
+class AbortContext:
+    def __init__(self):
+        self.code = None
+        self.details = None
+
+    def abort(self, code, details):
+        self.code = code
+        self.details = details
+        raise RpcAbort
+
+
+def request(
+    periods: list[Period],
+    *,
+    start: int = 9,
+    end: int = 17,
+    days: str = "12345",
+    gap: int = 0,
+    maxdays: int = 5,
+) -> Request:
+    return Request(start, end, days, gap, maxdays, periods)
+
+
+def single(*times: tuple[int, float], duration: float = 1) -> Period:
+    return Period(
+        periodsPerClass=1,
+        periodTimes=[value for time in times for value in time],
+        durations=[duration],
+    )
+
+
+def selected_meetings(problem, solution):
+    return [
+        meeting
+        for meeting in problem.meetings
+        if solution.options[meeting.activity] == meeting.option
+    ]
+
+
+def assert_valid(test_case: unittest.TestCase, problem, solution) -> None:
+    test_case.assertEqual(len(solution.options), len(problem.option_count))
+    test_case.assertEqual(len(solution.times), len(problem.option_count))
+    for activity, option in enumerate(solution.options):
+        test_case.assertIn(option, range(problem.option_count[activity]))
+        primary = next(
+            meeting
+            for meeting in problem.meetings
+            if meeting.activity == activity
+            and meeting.option == option
+            and meeting.primary
+        )
+        test_case.assertEqual(solution.times[activity], primary.code)
+
+    meetings = selected_meetings(problem, solution)
+    for activity, option in enumerate(solution.options):
+        expected = sum(
+            meeting.activity == activity and meeting.option == option
+            for meeting in problem.meetings
+        )
+        selected = sum(meeting.activity == activity for meeting in meetings)
+        test_case.assertEqual(selected, expected)
+
+    for index, left in enumerate(meetings):
+        for right in meetings[index + 1 :]:
+            if left.activity == right.activity or left.day != right.day:
+                continue
+            separated = (
+                left.start + left.duration + problem.gap <= right.start
+                or right.start + right.duration + problem.gap <= left.start
+            )
+            test_case.assertTrue(separated, (left, right))
+
+
+class ClingoSolverTests(unittest.TestCase):
+    def test_returns_three_distinct_optimal_alternatives(self):
+        result = solve(request([single((1, 9), (2, 9), (3, 9))]))
+
+        self.assertEqual(
+            [solution.times for solution in result.solutions],
+            [(118,), (218,), (318,)],
+        )
+        self.assertTrue(all(solution.optimal for solution in result.solutions))
+
+    def test_keeps_grouped_periods_together(self):
+        grouped = Period(
+            periodsPerClass=2,
+            periodTimes=[1, 9, 3, 9],
+            durations=[1, 1],
+        )
+        clashes_on_wednesday = single((3, 9), (2, 9))
+
+        result = solve(request([grouped, clashes_on_wednesday]))
+
+        self.assertEqual(result.primary.times, (118, 218))
+        self.assertEqual(result.primary.options, (0, 1))
+
+    def test_detects_a_clash_in_the_second_grouped_meeting(self):
+        grouped = Period(
+            periodsPerClass=2,
+            periodTimes=[1, 9, 3, 9],
+            durations=[1, 1],
+        )
+        clashes_on_wednesday = single((3, 9))
+
+        result = solve(request([grouped, clashes_on_wednesday]))
+
+        self.assertEqual(result.solutions, ())
+
+    def test_requested_gap_is_a_hard_constraint(self):
+        first = single((1, 9))
+        second = single((1, 10), (1, 11))
+
+        result = solve(request([first, second], gap=1))
+
+        self.assertEqual(result.primary.times, (118, 122))
+
+    def test_reports_each_preference_compromise(self):
+        outside_days = single((2, 8), duration=10)
+
+        result = solve(request([outside_days], start=9, end=17, days="1", maxdays=1))
+
+        self.assertEqual(
+            [
+                (item.code, item.priority, item.count)
+                for item in result.primary.violations
+            ],
+            [
+                ("outside_selected_days", 3, 1),
+                ("before_earliest_start", 1, 1),
+                ("after_latest_end", 1, 1),
+            ],
+        )
+        self.assertEqual(result.primary.cost, (1, 0, 2))
+        self.assertFalse(result.primary.optimal)
+
+    def test_reports_excess_campus_days(self):
+        result = solve(request([single((1, 9)), single((2, 9))], days="12", maxdays=1))
+
+        violation = next(
+            item
+            for item in result.primary.violations
+            if item.code == "exceeds_maximum_days"
+        )
+        self.assertEqual(violation.count, 1)
+
+    def test_returns_no_solution_when_every_combination_clashes(self):
+        result = solve(request([single((1, 9)), single((1, 9))]))
+
+        self.assertEqual(result.solutions, ())
+
+    def test_rejects_incomplete_alternatives(self):
+        invalid = Period(
+            periodsPerClass=2,
+            periodTimes=[1, 9],
+            durations=[1, 1],
+        )
+
+        with self.assertRaisesRegex(ValueError, "complete class alternatives"):
+            solve(request([invalid]))
+
+    def test_rejects_invalid_user_constraints(self):
+        with self.assertRaisesRegex(ValueError, "daily time window"):
+            solve(request([single((1, 9))], start=18, end=9))
+        with self.assertRaisesRegex(ValueError, "at least one weekday"):
+            solve(request([single((1, 9))], days=""))
+        with self.assertRaisesRegex(ValueError, "maxdays"):
+            solve(request([single((1, 9))], maxdays=0))
+        with self.assertRaisesRegex(ValueError, "half-hour"):
+            solve(request([single((1, 9.25))]))
+        with self.assertRaisesRegex(ValueError, "weekdays 1 through 5"):
+            solve(request([single((1, 9))], days="1,2"))
+
+    def test_is_repeatable(self):
+        value = request(
+            [
+                single((1, 9), (2, 9), (3, 9)),
+                single((1, 11), (2, 11), (3, 11)),
+            ]
+        )
+
+        first = solve(value)
+        second = solve(value)
+
+        self.assertEqual(first, second)
+
+
+class AutoTimetablerServiceTests(unittest.TestCase):
+    def test_grpc_response_preserves_legacy_fields(self):
+        grpc_request = autotimetabler_pb2.TimetableConstraints(
+            start=9,
+            end=17,
+            days="1",
+            gap=0,
+            maxdays=1,
+        )
+        grpc_request.periodInfo.add(
+            periodsPerClass=1,
+            periodTimes=[2, 8],
+            durations=[10],
+        )
+
+        response = AutoTimetablerServicer().FindBestTimetable(grpc_request, None)
+
+        self.assertEqual(list(response.times), [216])
+        self.assertFalse(response.optimal)
+
+    def test_grpc_response_reports_no_solution(self):
+        grpc_request = autotimetabler_pb2.TimetableConstraints(
+            start=9,
+            end=17,
+            days="12345",
+            gap=0,
+            maxdays=5,
+        )
+        for _ in range(2):
+            grpc_request.periodInfo.add(
+                periodsPerClass=1,
+                periodTimes=[1, 9],
+                durations=[1],
+            )
+
+        response = AutoTimetablerServicer().FindBestTimetable(grpc_request, None)
+
+        self.assertEqual(list(response.times), [])
+        self.assertFalse(response.optimal)
+
+    def test_grpc_response_rejects_invalid_constraints(self):
+        grpc_request = autotimetabler_pb2.TimetableConstraints(
+            start=18,
+            end=9,
+            days="12345",
+            gap=0,
+            maxdays=5,
+        )
+        grpc_request.periodInfo.add(
+            periodsPerClass=1,
+            periodTimes=[1, 9],
+            durations=[1],
+        )
+        context = AbortContext()
+
+        with self.assertRaises(RpcAbort):
+            AutoTimetablerServicer().FindBestTimetable(grpc_request, context)
+
+        self.assertEqual(context.code, grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertIn("daily time window", context.details)
+
+
+day_and_time = st.tuples(
+    st.integers(min_value=1, max_value=5),
+    st.integers(min_value=16, max_value=40).map(lambda slot: slot / 2),
+)
+
+
+@st.composite
+def simple_requests(draw):
+    activity_count = draw(st.integers(min_value=1, max_value=5))
+    periods = []
+    for _ in range(activity_count):
+        options = draw(
+            st.lists(
+                day_and_time,
+                min_size=1,
+                max_size=4,
+                unique=True,
+            )
+        )
+        duration = draw(st.sampled_from([0.5, 1, 1.5, 2]))
+        periods.append(single(*options, duration=duration))
+    return request(periods, start=0, end=24, days="12345", maxdays=5)
+
+
+@st.composite
+def grouped_requests(draw):
+    activity_count = draw(st.integers(min_value=1, max_value=4))
+    periods = []
+    for _ in range(activity_count):
+        periods_per_class = draw(st.integers(min_value=1, max_value=2))
+        option_count = draw(st.integers(min_value=1, max_value=3))
+        times = draw(
+            st.lists(
+                day_and_time,
+                min_size=periods_per_class * option_count,
+                max_size=periods_per_class * option_count,
+                unique=True,
+            )
+        )
+        durations = draw(
+            st.lists(
+                st.sampled_from([0.5, 1, 1.5, 2]),
+                min_size=periods_per_class,
+                max_size=periods_per_class,
+            )
+        )
+        periods.append(
+            Period(
+                periodsPerClass=periods_per_class,
+                periodTimes=[value for time in times for value in time],
+                durations=durations,
+            )
+        )
+    return request(periods, start=0, end=24, days="12345", maxdays=5)
+
+
+@st.composite
+def preference_requests(draw):
+    base = draw(simple_requests())
+    allowed_days = draw(
+        st.lists(
+            st.integers(min_value=1, max_value=5),
+            min_size=1,
+            max_size=5,
+            unique=True,
+        )
+    )
+    return request(
+        base.periodInfo,
+        start=draw(st.integers(min_value=8, max_value=12)),
+        end=draw(st.integers(min_value=14, max_value=22)),
+        days="".join(str(day) for day in sorted(allowed_days)),
+        gap=draw(st.integers(min_value=0, max_value=2)),
+        maxdays=draw(st.integers(min_value=1, max_value=5)),
+    )
+
+
+class ClingoPropertyTests(unittest.TestCase):
+    @settings(max_examples=60, deadline=None)
+    @given(grouped_requests())
+    def test_every_generated_solution_is_valid(self, generated_request):
+        problem = normalise_request(generated_request)
+        result = solve(generated_request)
+
+        for solution in result.solutions:
+            assert_valid(self, problem, solution)
+
+    @settings(max_examples=40, deadline=None)
+    @given(simple_requests())
+    def test_matches_ortools_hard_constraint_feasibility(self, generated_request):
+        with contextlib.redirect_stdout(io.StringIO()):
+            ortools_times, ortools_optimal = auto.sols(generated_request)
+        clingo_result = solve(generated_request, preference_mode="legacy")
+
+        self.assertEqual(bool(clingo_result.solutions), bool(ortools_times))
+        if ortools_times:
+            self.assertTrue(ortools_optimal)
+            self.assertTrue(clingo_result.primary.optimal)
+
+    @settings(max_examples=60, deadline=None)
+    @given(preference_requests())
+    def test_legacy_objective_matches_ortools(self, generated_request):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            auto.sols(generated_request)
+        clingo_result = solve(generated_request, preference_mode="legacy")
+
+        status = re.search(r"Status: (\w+)", output.getvalue()).group(1)
+        if status == "INFEASIBLE":
+            self.assertEqual(clingo_result.solutions, ())
+            return
+
+        match = re.search(
+            r"Number of constraints unsatisfied: ([0-9.]+)",
+            output.getvalue(),
+        )
+        ortools_cost = int(float(match.group(1)))
+        clingo_cost = clingo_result.primary.cost[0] if clingo_result.primary.cost else 0
+        self.assertEqual(clingo_cost, ortools_cost)

--- a/auto_server/timetable.lp
+++ b/auto_server/timetable.lp
@@ -1,0 +1,61 @@
+% Choose one published class alternative for every activity.
+#defined hierarchical/0.
+#defined legacy/0.
+
+1 { chosen(A, O) : option(A, O) } 1 :- activity(A).
+
+% Selecting an alternative selects all of its meetings.
+selected(A, O, M, D, S, L, C, P) :-
+    chosen(A, O),
+    meeting(A, O, M, D, S, L, C, P).
+
+% Meetings from different activities must not overlap. The requested gap is
+% added after both meetings, so the rule works regardless of their order.
+:- selected(A1, _, _, D, S1, L1, _, _),
+   selected(A2, _, _, D, S2, L2, _, _),
+   A1 < A2,
+   gap(G),
+   S1 < S2 + L2 + G,
+   S2 < S1 + L1 + G.
+
+% Selected weekdays are the highest-priority preference.
+disallowed_day(A, O, M, D) :-
+    selected(A, O, M, D, _, _, _, _),
+    not allowed_day(D).
+
+% Pick at most the requested number of campus days. Meetings outside those
+% days form the second preference tier.
+0 { campus_day(D) : weekday(D) } K :- max_days(K), K < 5.
+outside_compact_day(A, O, M, D) :-
+    selected(A, O, M, D, _, _, _, _),
+    max_days(K),
+    K < 5,
+    not campus_day(D).
+
+% Daily time-window violations are counted once per affected day.
+before_earliest(D) :-
+    selected(_, _, _, D, S, _, _, _),
+    earliest(E),
+    S < E.
+after_latest(D) :-
+    selected(_, _, _, D, S, L, _, _),
+    latest(E),
+    S + L > E.
+
+% Higher priorities dominate every possible improvement at lower priorities.
+:~ disallowed_day(A, O, M, D), hierarchical. [1@3, A, O, M, D]
+:~ outside_compact_day(A, O, M, D), hierarchical. [1@2, A, O, M, D]
+:~ before_earliest(D), hierarchical. [1@1, D, 0]
+:~ after_latest(D), hierarchical. [1@1, D, 1]
+
+% Legacy mode reproduces the flat OR-Tools objective for differential tests.
+:~ disallowed_day(A, O, M, D), legacy. [2@1, A, O, M, D]
+:~ outside_compact_day(A, O, M, D), legacy. [1@1, A, O, M, D]
+:~ before_earliest(D), legacy. [1@1, D, 0]
+:~ after_latest(D), legacy. [1@1, D, 1]
+
+#show chosen/2.
+#show disallowed_day/4.
+#show outside_compact_day/4.
+#show before_earliest/1.
+#show after_latest/1.

--- a/docs/clingo-autotimetabler-benchmark.md
+++ b/docs/clingo-autotimetabler-benchmark.md
@@ -1,0 +1,72 @@
+# Autotimetabler solver comparison
+
+## Result
+
+Clingo preserved the legacy OR-Tools objective on generated differential tests
+and reduced solve time in the small and medium synthetic workloads. The
+collision-dense result was within 2 ms in both pass orders, where Clingo was
+4.2 percent slower by the combined median.
+
+Each timing pass warmed the solver once, then measured 30 fresh calls in one
+process. The second pass reversed solver order. The values below are the median
+milliseconds from the OR-Tools-first and Clingo-first passes.
+
+| Workload | Shape | OR-Tools | Clingo | Median speedup |
+| --- | --- | ---: | ---: | ---: |
+| Representative small | 4 activities, 8 options each | 4.758 / 4.519 | 1.230 / 1.254 | 3.74x |
+| Representative medium | 8 activities, 12 options each | 5.774 / 5.754 | 2.347 / 2.321 | 2.47x |
+| Collision dense | 12 activities, 20 options each | 45.284 / 45.719 | 47.204 / 47.652 | 0.96x |
+
+The Clingo measurements use the new hierarchical preference model. A separate
+legacy-mode Clingo run, used to isolate solver behavior from the new preference
+order, recorded medians of 1.213 ms, 2.296 ms, and 29.382 ms.
+
+## Memory and deployment size
+
+`/usr/bin/time -v` measured each complete benchmark process. Peak resident set
+size was 126,040 KiB for OR-Tools and 84,924 KiB for hierarchical Clingo in the
+first pass. The reversed pass measured 126,304 KiB and 83,892 KiB. Clingo used
+32.6 to 33.6 percent less peak memory.
+
+Clean Docker builds used the same `python:3.10.17-slim-bookworm` base and each
+revision's production requirements:
+
+| Image | Size |
+| --- | ---: |
+| OR-Tools on upstream `dev` at `229ff95e` | 188,544,049 bytes |
+| Clingo replacement | 69,580,539 bytes |
+
+The Clingo image is 63.1 percent smaller. The old requirements installed
+OR-Tools, NumPy, and pandas. The replacement service installs Clingo, gRPC, and
+protobuf.
+
+## Correctness controls
+
+Timing does not establish semantic equivalence. The test suite handles that
+separately:
+
+- 60 generated requests compare the exact flat objective cost between
+  OR-Tools and Clingo legacy mode.
+- 40 generated requests compare hard feasibility.
+- 60 generated requests validate every Clingo result, including grouped
+  meetings and the requested gap.
+- A fixed regression proves that a clash in the second meeting of a grouped
+  class is rejected. The old period-reduction heuristic omitted that meeting.
+
+The workloads are deterministic synthetic cases, not production request
+samples. Run the benchmark with:
+
+```sh
+cd auto_server
+python benchmarks/compare_solvers.py --solver ortools --repeats 30
+python benchmarks/compare_solvers.py --solver clingo-hierarchical --repeats 30
+```
+
+## Environment
+
+- Date: 2026-07-23
+- CPU: AMD Ryzen 9 9950X, 16 cores and 32 threads
+- OS: Linux 7.0.0-27-generic x86-64
+- Python: 3.10.20
+- OR-Tools: 9.10.4067
+- Clingo: 5.8.0

--- a/docs/clingo-autotimetabler.md
+++ b/docs/clingo-autotimetabler.md
@@ -1,0 +1,68 @@
+# Clingo autotimetabler
+
+## Decision
+
+Replace the OR-Tools CP-SAT model with Clingo only if the new solver proves a
+product advantage while preserving the existing timetable contract.
+
+The existing service chooses one class alternative for each activity. It treats
+class clashes and the requested gap as hard constraints. Earliest start, latest
+end, selected weekdays, and maximum campus days are weighted preferences. The
+service returns the first period's `day * 100 + half-hour slot` value for each
+activity.
+
+Clingo fits this finite choice problem directly. One choice rule selects each
+class alternative. Integrity constraints reject overlapping meetings. Weak
+constraints rank the remaining answer sets. Clingo's Python API exposes model
+costs and proven optimal models without shelling out to a subprocess.
+
+The direct encoding also removes a correctness problem in `auto.py`.
+`hasConsecutivePeriods` returns true for every two-period class with one
+alternative because its comparison range is empty. `reducePeriodInfo` then
+merges the periods, even when they occur on different days, and the overlap
+model never sees the second meeting. The Clingo model keeps every meeting in an
+alternative and rejects clashes against any of them. A fixed regression and
+generated grouped-period tests cover that behavior.
+
+Telingo is not part of this design. Telingo unfolds state traces and adds past
+and future temporal operators. A NoTangles timetable is one static assignment,
+so temporal trace semantics would add machinery without expressing a missing
+requirement.
+
+asprin is also excluded from the runtime. It offers useful qualitative
+preference relations, but version 3.1.0 fails against the selected Clingo 5.8
+Python API. The unreleased 3.1.2 beta branch passes its bundled subset example,
+but depending on an unreleased source revision is unnecessary here. The same
+preference order is expressed with standard Clingo weak constraints.
+
+## Acceptance matrix
+
+| Claim | Required evidence |
+| --- | --- |
+| Existing clients remain compatible | The primary result keeps the existing `times` and `optimal` fields and time encoding. |
+| Every returned timetable is valid | Property tests prove exactly one alternative per activity, grouped meetings stay together, and no meetings overlap after applying the requested gap. |
+| Preferences are deliberate | The ASP encoding assigns named priority levels instead of relying on an undocumented flat Boolean sum. |
+| The replacement is measured | Differential tests compare both solvers over fixed regressions and generated requests. Benchmarks record solve time, memory, and image dependency size. |
+| Operations stay simple | The Python gRPC service remains the deployment boundary and uses the supported `clingo` Python package. |
+
+## Preference order
+
+The replacement uses lexicographic priorities. A violation at a higher priority
+cannot be traded for any number of lower-priority improvements.
+
+1. Keep meetings on the weekdays selected by the user.
+2. Keep the timetable within the requested number of campus days.
+3. Keep meetings within the requested daily time window.
+
+Class clashes and the requested gap remain hard constraints.
+
+The response reports whether every preference was satisfied. A valid timetable
+is not discarded merely because a preference cannot be met.
+
+## Sources
+
+- [Clingo repository and license](https://github.com/potassco/clingo)
+- [Clingo 5.8 Python API](https://potassco.org/clingo/python-api/5.8/)
+- [Telingo repository and temporal semantics](https://github.com/potassco/telingo)
+- [asprin preference framework](https://github.com/potassco/asprin)
+- [ASP-Timetable example](https://github.com/Adamouization/ASP-Timetable)


### PR DESCRIPTION
## Summary

- Replace the autotimetabler's OR-Tools CP-SAT runtime with Clingo 5.8.
- Preserve the existing gRPC response fields, time encoding, and browser
  behavior.
- Encode class selection, grouped meetings, clashes, requested gaps, and
  preference priorities in `timetable.lp`.
- Add fixed regressions, generated differential tests, benchmarks, and a
  dedicated autotimetabler CI job.

## Why

The current period reduction can omit a meeting from a grouped class. A clash
against that omitted meeting can therefore pass through the old model. The
Clingo encoding keeps every meeting attached to its class alternative and
checks every meeting for overlaps.

Clingo also gives the project a declarative preference model that later PRs can
inspect. The runtime migration in this PR does not expose a new API or UI.

## Compatibility

`FindBestTimetable` still returns the existing `times` and `optimal` fields.
The `day * 100 + half-hour slot` encoding is unchanged. The NestJS and React
clients require no changes in this PR.

Invalid solver requests now return gRPC `INVALID_ARGUMENT` instead of failing
inside the model.

## Evidence

- `python -m unittest discover -s tests -v`: 16 tests passed.
- Generated differential checks compare legacy objective cost on 60 requests
  and hard feasibility on 40 requests.
- Generated validity checks cover 60 requests, including grouped meetings and
  requested gaps.
- A fixed regression rejects a clash against the second meeting of a grouped
  class.
- `jscpd`: 0 clones and 0.0% duplication in the new solver and tests.
- `actionlint .github/workflows/ci.yml`: passed.
- `python -m compileall -q auto_server`: passed.
- `docker build`: passed with the production requirements.

Measured results and the exact environment are recorded in
`docs/clingo-autotimetabler-benchmark.md`. The representative small and medium
synthetic workloads measured 3.74x and 2.47x median speedups. The
collision-dense workload measured 0.96x. Peak process memory fell by 32.6% to
33.6%, and the production image fell from 188,544,049 bytes to 69,580,539
bytes.

## Review guide

1. Read `auto_server/timetable.lp` for the hard constraints and preference
   priorities.
2. Read `auto_server/clingo_solver.py` for request normalization and model
   decoding.
3. Check the grouped-meeting regression and generated comparisons in
   `auto_server/tests/test_clingo_solver.py`.
4. Check `auto_server/server.py` last to confirm the old response contract is
   unchanged.

## Rollout

The gRPC deployment boundary and HTTP client contract do not change. The
runtime can be rolled back by reverting this PR and rebuilding the
autotimetabler image.
