### PR TITLE
Fixed missing classes when scheduling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,6 +40,7 @@ import {
   ClassData,
   CourseCode,
   CourseData,
+  CourseSelection,
   DisplayTimetablesMap,
   InInventory,
   SelectedClasses,
@@ -288,14 +289,20 @@ const App: React.FC = () => {
    * @param callback An optional callback function to be executed using the course data
    */
   const handleSelectCourse = async (
-    data: string | string[],
+    data: CourseSelection | CourseSelection[],
     noInit?: boolean,
     callback?: (_selectedCourses: CourseData[]) => void,
   ) => {
-    const codes: string[] = Array.isArray(data) ? data : [data];
+    const selections: CourseSelection[] = Array.isArray(data) ? data : [data];
     Promise.all(
-      codes.map((code) =>
-        getCourseInfo(term.substring(0, 2), code, term.substring(2), convertToLocalTimezone).catch((err) => {
+      selections.map((selection) =>
+        getCourseInfo(
+          term.substring(0, 2),
+          selection.code,
+          term.substring(2),
+          convertToLocalTimezone,
+          selection.career,
+        ).catch((err) => {
           return err;
         }),
       ),
@@ -383,8 +390,9 @@ const App: React.FC = () => {
     }
 
     if (!storage.get('timetables')?.[term][selectedTimetable]) return;
+    const savedCourses: CourseData[] = storage.get('timetables')[term][selectedTimetable].selectedCourses;
     handleSelectCourse(
-      storage.get('timetables')[term][selectedTimetable].selectedCourses.map((course: CourseData) => course.code),
+      savedCourses.map((course) => ({ code: course.code, career: course.career })),
       true,
       (newSelectedCourses) => {
         const timetableSelectedClasses: SelectedClasses =

--- a/client/src/api/getCourseInfo.ts
+++ b/client/src/api/getCourseInfo.ts
@@ -96,17 +96,19 @@ const sortUnique = (arr: number[]): number[] => {
  * @param term The term that the course is offered in
  * @param courseCode The code of the course to fetch
  * @param isConvertToLocalTimezone Whether the user wants to convert the course periods into their local timezone
+ * @param career The career of the course to fetch ("Undergraduate" or "Postgraduate")
  * @return A promise containing the information of the course that is offered in the
  * current year and term
  *
  * @example
- * const selectedCourseClasses = await getCourseInfo('T1', 'COMP1511', true)
+ * const selectedCourseClasses = await getCourseInfo('T1', 'COMP1511', '2025', true, 'Undergraduate')
  */
 const getCourseInfo = async (
   term: string,
   courseCode: CourseCode,
   year: string,
   isConvertToLocalTimezone: boolean,
+  career?: string,
 ): Promise<CourseData> => {
   try {
     const { data } = await client.query({
@@ -115,7 +117,7 @@ const getCourseInfo = async (
     });
     if (data === undefined) throw new NetworkError('Internal server error');
 
-    const json: DbCourse = graphQLCourseToDbCourse(data);
+    const json: DbCourse = graphQLCourseToDbCourse(data, career);
     json.classes.forEach((dbClass) => {
       // Some courses split up a single class into two separate classes. e.g. CHEM1011 does it (as of 22T3)
       // because one half of the course is taught by one lecturer and the other half is taught by another.

--- a/client/src/api/getCourseInfo.ts
+++ b/client/src/api/getCourseInfo.ts
@@ -9,8 +9,8 @@ import { dbCourseToCourseData } from '../utils/DbCourse';
 import { graphQLCourseToDbCourse } from '../utils/graphQLCourseToDbCourse';
 
 const GET_COURSE_INFO: TypedDocumentNode<CoursesData, GetCourseInfoVars> = gql`
-  query GetCourseInfo($courseCode: String!, $term: String!, $year: String!) {
-    courses(where: { course_code: { _eq: $courseCode } }) {
+  query GetCourseInfo($courseCode: String!, $term: String!, $year: Int!) {
+    courses(where: { course_code: { _eq: $courseCode }, year: { _eq: $year } }) {
       course_code
       course_name
       classes(where: { term: { _eq: $term }, year: { _eq: $year }, activity: { _neq: "Course Enrolment" } }) {
@@ -111,7 +111,7 @@ const getCourseInfo = async (
   try {
     const { data } = await client.query({
       query: GET_COURSE_INFO,
-      variables: { courseCode, term, year },
+      variables: { courseCode, term, year: Number(year) },
     });
     if (data === undefined) throw new NetworkError('Internal server error');
 

--- a/client/src/api/getCoursesList.ts
+++ b/client/src/api/getCoursesList.ts
@@ -8,15 +8,15 @@ const toCoursesList = (data: FetchedCourse[]): CoursesList =>
   data.map((course) => ({
     code: course.course_code,
     name: course.course_name,
-    online: course.online,
-    inPerson: course.inPerson,
+    online: course.modes.includes('Online'),
+    inPerson: course.modes.includes('In Person'),
     career: course.career,
     faculty: course.faculty,
   }));
 
 const GET_COURSE_LIST: TypedDocumentNode<{ courses: FetchedCourse[] }, { term: string }> = gql`
   query GetCoursesByTerm($term: String!) {
-    courses(where: { terms: { _ilike: $term } }) {
+    courses(where: { classes: { term: { _eq: $term } } }) {
       campus
       career
       faculty
@@ -44,8 +44,7 @@ const GET_COURSE_LIST: TypedDocumentNode<{ courses: FetchedCourse[] }, { term: s
  */
 const getCoursesList = async (term: string): Promise<CoursesListWithDate> => {
   try {
-    const termWithWildcard = `%${term}%`;
-    const { data } = await client.query({ query: GET_COURSE_LIST, variables: { term: termWithWildcard } });
+    const { data } = await client.query({ query: GET_COURSE_LIST, variables: { term } });
     if (data === undefined) throw new NetworkError('Internal server error');
 
     return {

--- a/client/src/components/controls/CourseSelect.tsx
+++ b/client/src/components/controls/CourseSelect.tsx
@@ -216,8 +216,8 @@ const CourseSelect: React.FC<CourseSelectProps> = ({ assignedColors, handleSelec
 
     setSelectedValue(
       selectedCourses
-        .map((x) => x.code) // Get the course code of each course
-        .map((code) => coursesList.find((course) => course.code === code)) // Get the corresponding CourseOverview for each CourseData object
+        // Get the corresponding CourseOverview for each CourseData object
+        .map((x) => coursesList.find((course) => course.code === x.code && course.career === x.career))
         .filter((overview): overview is CourseOverview => overview !== undefined),
     );
   }, [selectedCourses, coursesList]);
@@ -319,8 +319,9 @@ const CourseSelect: React.FC<CourseSelectProps> = ({ assignedColors, handleSelec
 
   const onChange = (_: any, value: CoursesList) => {
     if (value.length > selectedValue.length) {
-      handleSelect(value[value.length - 1].code);
-      setSelectedValue([...value]);
+      const added = value[value.length - 1];
+      handleSelect({ code: added.code, career: added.career });
+      setSelectedValue(value.filter((course, index) => index === value.length - 1 || course.code !== added.code));
     }
     setOptions(defaultOptions);
     setInputValue('');
@@ -439,7 +440,9 @@ const CourseSelect: React.FC<CourseSelectProps> = ({ assignedColors, handleSelec
             <li key={key} {...rest}>
               <StyledOption>
                 <StyledIcon>
-                  {selectedValue.find((course: CourseOverview) => course.code === option.code) ? (
+                  {selectedValue.find(
+                    (course: CourseOverview) => course.code === option.code && course.career === option.career,
+                  ) ? (
                     <CheckRounded />
                   ) : (
                     <AddRounded />

--- a/client/src/interfaces/Courses.ts
+++ b/client/src/interfaces/Courses.ts
@@ -17,8 +17,7 @@ export interface CoursesListWithDate {
 export interface FetchedCourse {
   course_code: CourseCode;
   course_name: string;
-  online: boolean;
-  inPerson: boolean;
+  modes: string[];
   career: string;
   faculty: string;
 }

--- a/client/src/interfaces/Database.ts
+++ b/client/src/interfaces/Database.ts
@@ -3,6 +3,7 @@ import { Activity, CourseCode, Section, Status } from './Periods';
 export interface DbCourse {
   courseCode: CourseCode;
   name: string;
+  career: string;
   classes: DbClass[];
 }
 

--- a/client/src/interfaces/GraphQLCourseInfo.ts
+++ b/client/src/interfaces/GraphQLCourseInfo.ts
@@ -17,7 +17,7 @@ interface Class {
   class_id: string;
 }
 
-interface Course {
+export interface Course {
   __typename: 'courses';
   course_code: string;
   course_name: string;

--- a/client/src/interfaces/GraphQLCourseInfo.ts
+++ b/client/src/interfaces/GraphQLCourseInfo.ts
@@ -31,5 +31,5 @@ export interface CoursesData {
 export interface GetCourseInfoVars {
   courseCode: string;
   term: string;
-  year: string;
+  year: number;
 }

--- a/client/src/interfaces/Periods.ts
+++ b/client/src/interfaces/Periods.ts
@@ -11,9 +11,17 @@ export type SelectedClasses = Record<CourseCode, Record<Activity, ClassData | In
 export type CreatedEvents = Record<EventCode, EventPeriod>;
 export type EventMetadata = EventData & EventTime;
 
+// A course code (e.g. COMP4511) can be offered to both undergraduates and postgraduates
+// with different classes, so the career is needed to determine which course to fetch.
+export interface CourseSelection {
+  code: CourseCode;
+  career: string;
+}
+
 export interface CourseData {
   code: CourseCode;
   name: string;
+  career: string;
   earliestStartTime: number;
   latestFinishTime: number;
   activities: Record<Activity, ClassData[]>;
@@ -30,6 +38,7 @@ export interface ClassData {
   classNo: string;
   courseCode: CourseCode;
   courseName: string;
+  career: string;
   activity: Activity;
   status: Status;
   enrolments: number;

--- a/client/src/interfaces/PropTypes.ts
+++ b/client/src/interfaces/PropTypes.ts
@@ -2,7 +2,17 @@ import { PopoverOrigin, SelectChangeEvent } from '@mui/material';
 import { ReactNode } from 'react';
 
 import { ClassCard } from '../utils/Drag';
-import { ClassData, ClassPeriod, CourseCode, CourseData, EventPeriod, InInventory, Location, Section } from './Periods';
+import {
+  ClassData,
+  ClassPeriod,
+  CourseCode,
+  CourseData,
+  CourseSelection,
+  EventPeriod,
+  InInventory,
+  Location,
+  Section,
+} from './Periods';
 
 export interface AppContextProviderProps {
   children: ReactNode;
@@ -18,14 +28,22 @@ export interface UserContextProviderProps {
 
 export interface CourseSelectProps {
   assignedColors: Record<string, string>;
-  handleSelect(data: string | string[], a?: boolean, callback?: (_selectedCourses: CourseData[]) => void): void;
+  handleSelect(
+    data: CourseSelection | CourseSelection[],
+    a?: boolean,
+    callback?: (_selectedCourses: CourseData[]) => void,
+  ): void;
   handleRemove(courseCode: CourseCode): void;
 }
 
 export interface ControlsProps {
   assignedColors: Record<string, string>;
   handleSelectClass(classData: ClassData): void;
-  handleSelectCourse(data: string | string[], a?: boolean, callback?: (_selectedCourses: CourseData[]) => void): void;
+  handleSelectCourse(
+    data: CourseSelection | CourseSelection[],
+    a?: boolean,
+    callback?: (_selectedCourses: CourseData[]) => void,
+  ): void;
   handleRemoveCourse(courseCode: CourseCode): void;
 }
 

--- a/client/src/utils/DbCourse.ts
+++ b/client/src/utils/DbCourse.ts
@@ -150,6 +150,7 @@ export const dbCourseToCourseData = (dbCourse: DbCourse, isConvertToLocalTimezon
   const courseData: CourseData = {
     code: dbCourse.courseCode,
     name: dbCourse.name,
+    career: dbCourse.career,
     activities: {},
     inventoryData: {},
     earliestStartTime: 24,
@@ -161,6 +162,7 @@ export const dbCourseToCourseData = (dbCourse: DbCourse, isConvertToLocalTimezon
       id: uuidv4(),
       courseCode: dbCourse.courseCode,
       courseName: dbCourse.name,
+      career: dbCourse.career,
       activity: dbClass.activity,
       status: dbClass.status,
       enrolments: dbClass.courseEnrolment.enrolments,

--- a/client/src/utils/graphQLCourseToDbCourse.ts
+++ b/client/src/utils/graphQLCourseToDbCourse.ts
@@ -1,5 +1,5 @@
 import { DbCourse } from '../interfaces/Database';
-import { CoursesData } from '../interfaces/GraphQLCourseInfo';
+import { Course, CoursesData } from '../interfaces/GraphQLCourseInfo';
 import { Status } from '../interfaces/Periods';
 
 const statusMapping: Record<string, Status> = {
@@ -9,21 +9,36 @@ const statusMapping: Record<string, Status> = {
 };
 
 /**
+ * A filter picking the course with specific career from a list of courses
+ *
+ * @param courses A list of courses
+ * @param career A career to match ("Undergraduate" or "Postgraduate")
+ * @return A course matching the career
+ */
+const pickOffering = (courses: Course[], career: string): Course => {
+  const match = courses.find((course) => course.classes.some((classItem) => classItem.class_id.includes(career)));
+  if (match) return match;
+  else return courses[0];
+};
+
+/**
  * An adapter that formats a GraphQLCourse object to a DBCourse object
  *
  * @param CoursesData A GraphQLCourse object
+ * @param career A career of the course ("Undergraduate" or "Postgraduate")
  * @return A DBCourse object
  *
  * @example
  * const data = await client.query({query: GET_COURSE_INFO, variables: { courseCode, term }});
- * const json: DbCourse = graphQLCourseToDbCourse(data);
+ * const json: DbCourse = graphQLCourseToDbCourse(data, 'Undergraduate');
  */
-export const graphQLCourseToDbCourse = (graphQLCourse: CoursesData): DbCourse => {
-  const course = graphQLCourse.courses[0];
+export const graphQLCourseToDbCourse = (graphQLCourse: CoursesData, career?: string): DbCourse => {
+  const course = pickOffering(graphQLCourse.courses, career ?? '');
 
   return {
     courseCode: course.course_code,
     name: course.course_name,
+    career: career ?? '',
     classes: course.classes.map((classItem) => ({
       section: classItem.section,
       activity: classItem.activity,


### PR DESCRIPTION
### Description 🧾

Fixes #1156

For some courses like COMP4511, undergraduates and postgraduates have different available tutorials, but the frontend only shows the one for postgraduates for both undergraduates and postgraduates. This PR fixed the issue by adding a new `career` field on the frontend to distinguish them.

### Testing

Searching classes and comparing them with UNSW timetable and see whether classes are correct for undergraduates and postgraduates.

### Checklist

- [x] 📍 You have assigned yourself to this pull request.
- [x] 🔗 You have linked an issue to which this pull request closes.
- [x] 💭 Leave any relevant specific directions to reviewers.
- [x] 👀 No secrets in clear text in the pull request.
- [x] 🎟️ To categorise release notes, the pull request should be labelled with at least one of these labels:
  - `feature`: for application feature improvement or new features
  - `bug`: fixing something that previously wasn't working
  - `dev`: development-side related changes
  - `docker`: updates to the Docker code
  - `setup`: changes to the setup/infrastructure of the codebase
  - `test`: updates to internal testing
